### PR TITLE
docs: conventional commits and release workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,39 +11,73 @@ git clone https://github.com/craigmccaskill/todoist-cli.git
 cd todoist-cli
 python -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+make install
 ```
 
-2. Install pre-commit hooks:
+2. Verify everything works:
 
 ```bash
-pre-commit install
+make check
 ```
 
-## Running Checks
+## Common Commands
 
 ```bash
-# Lint
-ruff check .
-ruff format --check .
-
-# Type check
-mypy td/
-
-# Tests (CI enforces 85% minimum coverage)
-pytest
-
-# All at once
-ruff check . && ruff format --check . && mypy td/ && pytest
+make help       # Show all available targets
+make check      # Run lint + tests (the one command you need)
+make fmt        # Auto-format code
+make test       # Run tests only
+make lint       # Run linter + type checker only
+make examples   # Regenerate docs/examples.md
+make clean      # Remove build artifacts
 ```
+
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) for clear history and automated changelogs.
+
+**Format:** `<type>(<scope>): <description>`
+
+**Types:**
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature or command |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test` | Adding or updating tests |
+| `ci` | CI/CD workflow changes |
+| `chore` | Maintenance (deps, config, tooling) |
+
+**Examples:**
+```
+feat(tasks): add td undo command
+fix(output): handle empty task list in plain mode
+docs: update README with MCP section
+refactor(core): simplify project name resolution
+test(errors): add coverage for rate limit mapping
+ci: add coverage threshold to CI
+chore(deps): bump rich to v14
+```
+
+**Scope** is optional but encouraged — use the module name (`tasks`, `output`, `errors`, `config`, `core`, `ci`, `deps`).
+
+## Branching
+
+- Work on feature branches: `feat/description`, `fix/description`, `docs/description`
+- PR into `main`
+- CI must pass before merge
+- Keep PRs focused — one issue per PR when possible
 
 ## Making Changes
 
-1. Create a branch from `main`
+1. Create a branch from `main`: `git checkout -b feat/my-feature`
 2. Make your changes
-3. Ensure all checks pass (lint, types, tests)
+3. Run `make check` (must pass)
 4. Update `CHANGELOG.md` under `[Unreleased]` if the change is user-facing
-5. Open a pull request
+5. Commit with conventional commit message
+6. Push and open a pull request
 
 ## Code Style
 
@@ -52,6 +86,7 @@ ruff check . && ruff format --check . && mypy td/ && pytest
 - **Output**: All commands use `OutputFormatter` for Rich/JSON/Plain modes
 - **Errors**: All errors use structured `TdError` subclasses with codes and suggestions
 - **Types**: Full type annotations. `mypy --strict` must pass
+- **Coverage**: CI enforces 85% minimum
 
 ## Adding a New Command
 
@@ -60,7 +95,18 @@ ruff check . && ruff format --check . && mypy td/ && pytest
 3. Register the command in `td/cli/__init__.py`
 4. Add output methods to `td/cli/output.py` if needed
 5. Add tests in `tests/`
-6. Run `td schema` to verify the command appears in the manifest
+6. Update the schema test expected commands set
+7. Run `td schema` to verify the command appears in the manifest
+
+## Releasing
+
+Maintainers only:
+
+```bash
+make release VERSION=0.2.0
+```
+
+This bumps the version, updates CHANGELOG.md, commits, tags, and pushes. The CI release workflow handles PyPI publishing.
 
 ## Questions?
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint fmt check clean examples
+.PHONY: help install test lint fmt check clean examples release
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -26,3 +26,16 @@ examples: ## Regenerate command examples doc
 
 clean: ## Remove build artifacts
 	rm -rf dist/ build/ *.egg-info .coverage coverage.xml htmlcov/ .mypy_cache/ .ruff_cache/ .pytest_cache/
+
+release: check ## Release a new version (make release VERSION=x.y.z)
+ifndef VERSION
+	$(error VERSION is required. Usage: make release VERSION=0.2.0)
+endif
+	@echo "Releasing v$(VERSION)..."
+	@sed -i 's/__version__ = ".*"/__version__ = "$(VERSION)"/' td/__init__.py
+	@sed -i 's/## \[Unreleased\]/## [Unreleased]\n\n## [$(VERSION)] - $(shell date +%Y-%m-%d)/' CHANGELOG.md
+	git add td/__init__.py CHANGELOG.md
+	git commit -m "chore(release): v$(VERSION)"
+	git tag -a "v$(VERSION)" -m "v$(VERSION)"
+	git push origin main --tags
+	@echo "Done. v$(VERSION) tagged and pushed."


### PR DESCRIPTION
## Summary
- Rewrite CONTRIBUTING.md with conventional commit format, branching strategy, and Makefile-first dev workflow
- Add `make release VERSION=x.y.z` that bumps version, updates changelog, commits, tags, and pushes

## Test plan
- [ ] `make help` shows release target
- [ ] `make check` passes
- [ ] CONTRIBUTING.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)