### PR TITLE
feat(projects): add td project-add command

### DIFF
--- a/td/cli/__init__.py
+++ b/td/cli/__init__.py
@@ -60,7 +60,7 @@ def cli(ctx: click.Context, output_json: bool, plain: bool) -> None:
 def _register_commands() -> None:
     from td.cli.config_cmd import completions, init
     from td.cli.labels import labels
-    from td.cli.projects import projects
+    from td.cli.projects import project_add, projects
     from td.cli.schema_cmd import schema
     from td.cli.sections import sections
     from td.cli.tasks import add, delete, done, edit, inbox, ls, quick, undo
@@ -77,6 +77,7 @@ def _register_commands() -> None:
     cli.add_command(quick)
     cli.add_command(undo)
     cli.add_command(projects)
+    cli.add_command(project_add)
     cli.add_command(sections)
     cli.add_command(labels)
 

--- a/td/cli/projects.py
+++ b/td/cli/projects.py
@@ -6,7 +6,7 @@ import click
 
 from td.cli.output import OutputFormatter
 from td.core.client import get_client
-from td.core.projects import _collect_projects
+from td.core.projects import _collect_projects, create_project, resolve_project
 
 
 def _get_formatter(ctx: click.Context) -> OutputFormatter:
@@ -27,3 +27,35 @@ def projects(ctx: click.Context, search: str | None) -> None:
         all_projects = _collect_projects(api)
 
     fmt.project_list(all_projects)
+
+
+@click.command(name="project-add")
+@click.argument("name", nargs=-1, required=True)
+@click.option(
+    "--parent",
+    "parent_name",
+    help="Parent project name or ID (for sub-projects).",
+)
+@click.option("--favorite", is_flag=True, help="Mark as favorite.")
+@click.pass_context
+def project_add(
+    ctx: click.Context,
+    name: tuple[str, ...],
+    parent_name: str | None,
+    favorite: bool,
+) -> None:
+    """Create a new project."""
+    api = get_client()
+    fmt = _get_formatter(ctx)
+
+    parent_id = None
+    if parent_name:
+        parent_id = resolve_project(api, parent_name).id
+
+    project = create_project(
+        api,
+        " ".join(name),
+        parent_id=parent_id,
+        is_favorite=favorite,
+    )
+    fmt.item_created("project", project)

--- a/td/core/projects.py
+++ b/td/core/projects.py
@@ -44,6 +44,22 @@ def resolve_project(api: TodoistAPI, name_or_id: str) -> Project:
     )
 
 
+def create_project(
+    api: TodoistAPI,
+    name: str,
+    *,
+    parent_id: str | None = None,
+    is_favorite: bool = False,
+) -> Project:
+    """Create a new project."""
+    kwargs: dict[str, object] = {}
+    if parent_id:
+        kwargs["parent_id"] = parent_id
+    if is_favorite:
+        kwargs["is_favorite"] = True
+    return api.add_project(name, **kwargs)  # type: ignore[arg-type]
+
+
 def get_inbox_project(api: TodoistAPI) -> Project:
     """Find the Inbox project."""
     projects = _collect_projects(api)

--- a/tests/test_org_commands.py
+++ b/tests/test_org_commands.py
@@ -71,6 +71,55 @@ class TestProjectsCommand:
         assert len(data["data"]) == 1
 
 
+class TestProjectAddCommand:
+    @patch("td.cli.projects.get_client")
+    def test_creates_project(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        proj = _mock_project(name="New Project", id="p99")
+        api.add_project.return_value = proj
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "project-add", "New", "Project"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["data"]["name"] == "New Project"
+        api.add_project.assert_called_once()
+
+    @patch("td.cli.projects.get_client")
+    def test_creates_with_parent(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        parent = _mock_project(name="Work", id="p1")
+        api.get_projects.return_value = iter([[parent]])
+        child = _mock_project(name="Sub Project", id="p99")
+        api.add_project.return_value = child
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--json", "project-add", "Sub", "Project", "--parent", "Work"]
+        )
+
+        assert result.exit_code == 0
+        _, kwargs = api.add_project.call_args
+        assert kwargs["parent_id"] == "p1"
+
+    @patch("td.cli.projects.get_client")
+    def test_creates_favorite(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.add_project.return_value = _mock_project(name="Fav", is_favorite=True)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "project-add", "Fav", "--favorite"])
+
+        assert result.exit_code == 0
+        _, kwargs = api.add_project.call_args
+        assert kwargs["is_favorite"] is True
+
+
 class TestSectionsCommand:
     @patch("td.cli.sections.get_client")
     def test_lists_sections(self, mock_gc: MagicMock) -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -34,6 +34,7 @@ class TestSchemaCommand:
             "inbox",
             "quick",
             "undo",
+            "project-add",
             "projects",
             "sections",
             "labels",


### PR DESCRIPTION
## Summary
- New `td project-add` command to create projects from the CLI
- Supports `--parent` for sub-projects and `--favorite` flag
- Core function in `td/core/projects.py`, CLI in `td/cli/projects.py`
- 3 new tests (basic create, parent resolution, favorite flag)

## Test plan
- [ ] `make check` passes (118 tests, 92% coverage)
- [ ] `td project-add --help` shows correct usage
- [ ] `td --json project-add "Test Project"` returns created project JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)