### PR TITLE
chore(release): v0.2.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha] - 2026-03-24
+
+### Added
+- `td capture` — minimal-friction inbox append, no parsing (#32)
+- `td today` — morning dashboard: overdue + due today (#7)
+- `td next` — show highest priority task (#8)
+- `td log` — completed tasks today or `--week` (#10)
+- `td focus <project>` — single-project deep work view (#11)
+- `td project-add` — create projects from the CLI
+- `td undo` — reopen completed tasks (#16)
+- Numbered results — `td ls` shows row numbers, `td done 1` works (#12)
+- `--sort` and `--reverse` flags on list commands (#48)
+- `--ids` flag on `td ls` for Unix piping (#23)
+- `--debug` flag for API troubleshooting (#44)
+- Stdin piping for `td add` and `td quick` (#31, #21)
+- Name caching with 5-min TTL for project/label/section resolution (#28)
+- Result caching for numbered row references (10-min TTL)
+- Interactive `td init` — choose config file or env var (#19)
+- Configurable default output format via `TD_FORMAT` env or config (#20)
+- Configurable default sort via `TD_SORT` env or config
+- Smart `td ls` default — shows today + overdue, `--all` for everything (#17)
+- `-h` shorthand for `--help` on all commands
+- `SECURITY.md` vulnerability reporting policy (#34)
+- Coverage gate at 85% in CI (#36)
+- `Makefile` with dev workflow commands (#40)
+- Separate dependency groups in pyproject.toml (#39)
+- Conventional commits guide in CONTRIBUTING.md
+- `make release` workflow for versioning
+- Branch protection on main
+- Feature spec issue template
+
+### Changed
+- Priority help text now reads "1=urgent, 2=high, 3=medium, 4=low" (#18)
+
 ## [0.1.0-alpha] - 2026-03-24
 
 ### Added
-- Task commands: `add`, `ls`, `done`, `undo`, `edit`, `delete`, `quick`, `inbox`
-- Workflow commands: `today`, `next`, `log`, `focus`
-- Organization: `projects`, `project-add`, `sections`, `labels`
+- Task commands: `add`, `ls`, `done`, `edit`, `delete`, `quick`, `inbox`
+- Organization: `projects`, `sections`, `labels`
 - AI-native: `schema` capability manifest, structured JSON errors, TTY-aware output
 - `--idempotent` flag on `td add` to prevent duplicate creation
 - `--json`, `--plain` flags on all commands
-- `--sort` and `--reverse` flags on list commands (priority, due, project, created)
-- `--ids` flag on `td ls` for Unix piping
-- `--all` flag on `td ls` (default is today + overdue)
-- `-h` shorthand for `--help` on all commands
-- Configurable default output format (`TD_FORMAT` env, `default_format` in config)
-- Configurable default sort (`TD_SORT` env, `default_sort` in config)
 - `td init` for interactive auth setup
 - `td completions` for bash/zsh/fish shell completions
-- Shell completion generation via Click's `_TD_COMPLETE` mechanism
 - Config at `~/.config/td/config.toml` (respects `XDG_CONFIG_HOME`, `TD_CONFIG_DIR`)
 - `NO_COLOR` support
-- CI: multi-OS (ubuntu + macOS), multi-Python (3.10–3.13), coverage gate at 85%
+- CI: multi-OS (ubuntu + macOS), multi-Python (3.10–3.13)
 - Release workflow: build + publish to PyPI on tag
 - Pre-commit hooks, dependabot, issue/PR templates
-- SECURITY.md, CONTRIBUTING.md, AGENTS.md
-- `Makefile` with `make check`, `make test`, `make lint`, `make fmt`, `make release`
+- CONTRIBUTING.md, AGENTS.md
 - Example output documentation at `docs/examples.md` with generator script

--- a/td/__init__.py
+++ b/td/__init__.py
@@ -1,3 +1,3 @@
 """td — AI-native Todoist CLI."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0-alpha"


### PR DESCRIPTION
## Summary
Version bump and changelog update for v0.2.0-alpha.

See [CHANGELOG.md](CHANGELOG.md) for full details.

Highlights since v0.1.0-alpha:
- 5 workflow commands (today, next, log, focus, capture)
- Numbered results + row-number references
- Name caching with TTL
- Stdin piping, --debug, interactive init
- Sortable lists, --ids for piping
- 21 commands, 143 tests, 91% coverage