### PR TITLE
feat(tasks): natural language task refs without quotes

### DIFF
--- a/td/cli/tasks.py
+++ b/td/cli/tasks.py
@@ -320,33 +320,39 @@ def focus(
 
 
 @click.command()
-@click.argument("task_id")
+@click.argument("task_ref", nargs=-1, required=True)
 @click.pass_context
-def done(ctx: click.Context, task_id: str) -> None:
-    """Complete a task. Accepts row number, content match, or task ID."""
+def done(ctx: click.Context, task_ref: tuple[str, ...]) -> None:
+    """Complete a task. Accepts row number, content match, or task ID.
+
+    Examples: td done 1 | td done buy milk | td done 8bx9a0c2
+    """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task(task_id, api)
+    task_id = _resolve_task(" ".join(task_ref), api)
 
     complete_task(api, task_id)
     fmt.success(f"Completed task {task_id}", {"task_id": task_id})
 
 
 @click.command()
-@click.argument("task_id")
+@click.argument("task_ref", nargs=-1, required=True)
 @click.pass_context
-def undo(ctx: click.Context, task_id: str) -> None:
-    """Reopen a completed task. Accepts row number, content match, or task ID."""
+def undo(ctx: click.Context, task_ref: tuple[str, ...]) -> None:
+    """Reopen a completed task. Accepts row number, content match, or task ID.
+
+    Examples: td undo 1 | td undo buy milk | td undo 8bx9a0c2
+    """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task(task_id, api)
+    task_id = _resolve_task(" ".join(task_ref), api)
 
     uncomplete_task(api, task_id)
     fmt.success(f"Reopened task {task_id}", {"task_id": task_id})
 
 
 @click.command()
-@click.argument("task_id")
+@click.argument("task_ref", nargs=-1, required=True)
 @click.option("--content", help="New content.")
 @click.option(
     "--priority",
@@ -359,17 +365,20 @@ def undo(ctx: click.Context, task_id: str) -> None:
 @click.pass_context
 def edit(
     ctx: click.Context,
-    task_id: str,
+    task_ref: tuple[str, ...],
     content: str | None,
     priority: int | None,
     due: str | None,
     labels: tuple[str, ...],
     description: str | None,
 ) -> None:
-    """Update a task. Accepts row number, content match, or task ID."""
+    """Update a task. Accepts row number, content match, or task ID.
+
+    Examples: td edit 1 --due friday | td edit buy milk --priority 1
+    """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task(task_id, api)
+    task_id = _resolve_task(" ".join(task_ref), api)
 
     api_priority = (5 - priority) if priority else None
 
@@ -386,14 +395,17 @@ def edit(
 
 
 @click.command()
-@click.argument("task_id")
+@click.argument("task_ref", nargs=-1, required=True)
 @click.option("-y", "--yes", is_flag=True, help="Skip confirmation.")
 @click.pass_context
-def delete(ctx: click.Context, task_id: str, yes: bool) -> None:
-    """Delete a task. Accepts row number, content match, or task ID."""
+def delete(ctx: click.Context, task_ref: tuple[str, ...], yes: bool) -> None:
+    """Delete a task. Accepts row number, content match, or task ID.
+
+    Examples: td delete 1 -y | td delete buy milk -y
+    """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task(task_id, api)
+    task_id = _resolve_task(" ".join(task_ref), api)
     if not yes:
         if not sys.stdout.isatty():
             raise TdValidationError(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -75,4 +75,4 @@ class TestSchemaCommand:
 
         done_cmd = data["commands"]["done"]
         arg_names = [a["name"] for a in done_cmd["arguments"]]
-        assert "task_id" in arg_names
+        assert "task_ref" in arg_names


### PR DESCRIPTION
## Summary
Task commands now accept multi-word content without quotes:

```bash
td done buy milk
td edit blog post --due friday
td delete old task -y
td undo review pr
```

Changed `task_id` (single arg) to `task_ref` (nargs=-1) on done, undo, edit, delete. Words joined and passed through resolution chain.

## Test plan
- [ ] `make check` passes (153 tests, 91% coverage)
- [ ] `td done buy milk` works without quotes
- [ ] `td edit blog --due friday` correctly separates ref from flags
- [ ] `td done 1` still works (row number)

🤖 Generated with [Claude Code](https://claude.com/claude-code)