### PR TITLE
chore(ci): align lint job with local make lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - run: pip install ruff mypy
-      - run: ruff check .
-      - run: ruff format --check .
       - run: pip install -e ".[dev]"
-      - run: mypy td/
+      - run: make lint
 
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- CI lint job now uses `pip install -e .[dev]` + `make lint` instead of installing ruff/mypy separately with unpinned versions
- Ensures local and CI run identical tool versions and commands

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)