### PR TITLE
feat(edit): show current values when no flags provided

### DIFF
--- a/td/cli/tasks.py
+++ b/td/cli/tasks.py
@@ -380,6 +380,13 @@ def edit(
     fmt = _get_formatter(ctx)
     task_id = _resolve_task(" ".join(task_ref), api)
 
+    # No flags provided — show current task values
+    has_updates = content or priority or due or labels or description
+    if not has_updates:
+        task = api.get_task(task_id)
+        fmt.task(task)
+        return
+
     api_priority = (5 - priority) if priority else None
 
     task = edit_task(

--- a/tests/test_cli_extras.py
+++ b/tests/test_cli_extras.py
@@ -43,6 +43,21 @@ class TestEditCommand:
         assert data["ok"] is True
 
     @patch("td.cli.tasks.get_client")
+    def test_edit_no_flags_shows_task(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_task.return_value = _mock_task(content="Buy milk")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "edit", "t1"])
+
+        assert result.exit_code == 0
+        api.get_task.assert_called_once_with("t1")
+        api.update_task.assert_not_called()
+        data = json.loads(result.output)
+        assert data["ok"] is True
+
+    @patch("td.cli.tasks.get_client")
     def test_edit_with_priority(self, mock_gc: MagicMock) -> None:
         api = MagicMock()
         mock_gc.return_value = api


### PR DESCRIPTION
## Summary
- `td edit <ref>` with no update flags now displays the task's current values instead of silently doing nothing
- Calls `api.get_task()` and renders via `fmt.task()`

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)