### PR TITLE
chore(release): v0.4.0-alpha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,14 @@ Set `TD_API_TOKEN` env var (preferred for agents), or run `td init` interactivel
 - `td log` — completed tasks today. `--week` for this week
 - `td done <ref>` — complete task (row number, content match, or task ID — no quotes needed)
 - `td undo <ref>` — reopen a completed task (same ref formats as done)
-- `td edit <ref>` — update task fields (same ref formats as done)
+- `td edit <ref>` — update task fields (same ref formats as done). No flags = show current values
 - `td delete <ref> --yes` — delete task (same ref formats, `--yes` to skip confirmation)
 - `td projects` — list all projects
 - `td project-add <name>` — create a project (`--parent`, `--favorite`)
 - `td sections -p <project>` — list sections in a project
+- `td section-add <name> -p <project>` — create a section in a project
 - `td labels` — list all labels
+- `td label-add <name>` — create a label
 - `td schema` — full capability manifest as JSON
 
 ## Piping Behavior
@@ -89,11 +91,11 @@ JSON output includes `"created": true` or `"created": false`.
 pip install -e ".[dev]"
 pytest
 ruff check .
-mypy td/
+mypy src/td/
 ```
 
 ## Architecture
 
-- `td/core/` — pure business logic, no CLI dependency
-- `td/cli/` — Click commands and output formatting
-- `td/schema.py` — capability manifest generator
+- `src/td/core/` — pure business logic, no CLI dependency
+- `src/td/cli/` — Click commands and output formatting
+- `src/td/schema.py` — capability manifest generator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0-alpha] - 2026-03-25
+
+### Added
+- `td section-add <name> -p <project>` — create sections from the CLI (#77)
+- `td label-add <name>` — create labels from the CLI (#77)
+- `td edit <ref>` with no flags now shows current task values (#67)
+- Example generator covers all 22 commands (#69)
+
+### Changed
+- Migrated to `src/` layout for proper test isolation (#37)
+- CI lint job uses `make lint` instead of separate tool installs (#71)
+- `make release` creates a branch + PR instead of pushing directly to main (#68)
+- Auto-delete head branches on merge enabled (#70)
+
 ## [0.3.0-alpha] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Returns the existing task if identical content already exists. The JSON response
 ## Architecture
 
 ```
-td/
+src/td/
   core/       # Pure business logic — no CLI dependency
     tasks.py, projects.py, labels.py, sections.py, config.py, client.py
   cli/        # Thin Click frontend
@@ -163,7 +163,9 @@ The core is a library. The CLI is one frontend. An MCP server ([planned](https:/
 | `td projects` | List projects |
 | `td project-add` | Create a new project |
 | `td sections` | List sections in a project |
+| `td section-add` | Create a new section in a project |
 | `td labels` | List labels |
+| `td label-add` | Create a new label |
 | `td schema` | Output capability manifest (JSON) |
 | `td init` | Set up authentication (config file or env var) |
 | `td completions` | Generate shell completions (bash/zsh/fish) |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -30,6 +30,7 @@ Commands:
   focus        Focus on a single project — deep work mode.
   inbox        Show unprocessed inbox tasks.
   init         Set up authentication and configuration.
+  label-add    Create a new label.
   labels       List all labels.
   log          Show completed tasks — your end-of-day review.
   ls           List tasks.
@@ -38,6 +39,7 @@ Commands:
   projects     List all projects.
   quick        Natural language task creation.
   schema       Output full capability manifest as JSON.
+  section-add  Create a new section in a project.
   sections     List sections in a project.
   today        Show tasks due today and overdue — your morning dashboard.
   undo         Reopen a completed task.
@@ -50,7 +52,7 @@ Commands:
 
 ```
 $ td --version
-td, version 0.3.0-alpha
+td, version 0.4.0-alpha
 ```
 
 
@@ -647,10 +649,15 @@ Create a new section in a project.
 
 ```
 $ td --json section-add "In Progress" -p "Work"
-Usage: td [OPTIONS] COMMAND [ARGS]...
-Try 'td -h' for help.
-
-Error: No such command 'section-add'.
+{
+  "ok": true,
+  "type": "section_created",
+  "data": {
+    "id": "s2",
+    "name": "In Progress",
+    "created": true
+  }
+}
 ```
 
 ### `td --json labels`
@@ -707,10 +714,15 @@ Create a new label.
 
 ```
 $ td --json label-add urgent
-Usage: td [OPTIONS] COMMAND [ARGS]...
-Try 'td -h' for help.
-
-Error: No such command 'label-add'.
+{
+  "ok": true,
+  "type": "label_created",
+  "data": {
+    "id": "lbl1",
+    "name": "urgent",
+    "created": true
+  }
+}
 ```
 
 
@@ -724,7 +736,7 @@ Output the full capability manifest. Agents call this once to learn everything.
 $ td schema
 {
   "name": "td",
-  "version": "0.3.0-alpha",
+  "version": "0.4.0-alpha",
   "description": "AI-native Todoist CLI",
   "commands": {
     "add": {
@@ -968,6 +980,17 @@ $ td schema
       "arguments": [],
       "options": []
     },
+    "label-add": {
+      "description": "Create a new label.",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "text",
+          "required": true
+        }
+      ],
+      "options": []
+    },
     "labels": {
       "description": "List all labels.",
       "arguments": [],
@@ -1167,6 +1190,29 @@ $ td schema
       "description": "Output full capability manifest as JSON.",
       "arguments": [],
       "options": []
+    },
+    "section-add": {
+      "description": "Create a new section in a project.",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "text",
+          "required": true
+        }
+      ],
+      "options": [
+        {
+          "name": "project_name",
+          "type": "text",
+          "required": true,
+          "flags": [
+            "-p",
+            "--project"
+          ],
+          "help": "Project name or ID.",
+          "is_flag": false
+        }
+      ]
     },
     "sections": {
       "description": "List sections in a project.",
@@ -1652,10 +1698,22 @@ Options:
 
 ```
 $ td section-add --help
-Usage: td [OPTIONS] COMMAND [ARGS]...
-Try 'td -h' for help.
+Usage: td section-add [OPTIONS] NAME...
 
-Error: No such command 'section-add'.
+  Create a new section in a project.
+
+Options:
+  -p, --project TEXT  Project name or ID.  [required]
+  -h, --help          Show this message and exit.
+{
+  "ok": false,
+  "error": {
+    "code": "API_ERROR",
+    "message": "Unexpected error: 0",
+    "suggestion": "",
+    "details": {}
+  }
+}
 ```
 
 ### `td labels --help`
@@ -1684,10 +1742,21 @@ Options:
 
 ```
 $ td label-add --help
-Usage: td [OPTIONS] COMMAND [ARGS]...
-Try 'td -h' for help.
+Usage: td label-add [OPTIONS] NAME...
 
-Error: No such command 'label-add'.
+  Create a new label.
+
+Options:
+  -h, --help  Show this message and exit.
+{
+  "ok": false,
+  "error": {
+    "code": "API_ERROR",
+    "message": "Unexpected error: 0",
+    "suggestion": "",
+    "details": {}
+  }
+}
 ```
 
 ### `td schema --help`

--- a/src/td/__init__.py
+++ b/src/td/__init__.py
@@ -1,3 +1,3 @@
 """td — AI-native Todoist CLI."""
 
-__version__ = "0.3.0-alpha"
+__version__ = "0.4.0-alpha"


### PR DESCRIPTION
## Summary
- Version bump to 0.4.0-alpha
- CHANGELOG.md updated with all 7 sprint issues
- README.md: added section-add, label-add to commands table; updated architecture to src/ layout
- AGENTS.md: added new commands, updated paths, noted td edit no-flags behavior
- Regenerated docs/examples.md with v0.4.0-alpha version

🤖 Generated with [Claude Code](https://claude.com/claude-code)