### PR TITLE
chore(ci): add merge_group trigger for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds `merge_group:` trigger to CI workflow, required for GitHub merge queue to function
- No other workflow changes needed — `actions/checkout` handles merge group refs automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)