### PR TITLE
feat: td with no subcommand runs default command

### DIFF
--- a/src/td/cli/__init__.py
+++ b/src/td/cli/__init__.py
@@ -14,7 +14,7 @@ from td.core.config import load_config
 
 
 class TdGroup(click.Group):
-    """Custom Click group with structured error handling."""
+    """Custom Click group with structured error handling and default command."""
 
     def invoke(self, ctx: click.Context) -> None:
         try:
@@ -42,7 +42,11 @@ class TdGroup(click.Group):
         return OutputMode.JSON
 
 
-@click.group(cls=TdGroup, context_settings={"help_option_names": ["-h", "--help"]})
+@click.group(
+    cls=TdGroup,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    invoke_without_command=True,
+)
 @click.option("--json", "output_json", is_flag=True, help="Force JSON output.")
 @click.option("--plain", is_flag=True, help="Force plain text output (no color).")
 @click.option("--debug", is_flag=True, help="Show API request details on stderr.")
@@ -66,6 +70,13 @@ def cli(ctx: click.Context, output_json: bool, plain: bool, debug: bool) -> None
             stream=sys.stderr,
         )
         logging.getLogger("urllib3").setLevel(logging.DEBUG)
+
+    # If no subcommand was given, run the default command
+    if ctx.invoked_subcommand is None:
+        cmd_name = config.default_command
+        cmd = cli.get_command(ctx, cmd_name)
+        if cmd:
+            ctx.invoke(cmd)
 
 
 # Register subcommands (imported here to avoid circular imports)

--- a/src/td/core/config.py
+++ b/src/td/core/config.py
@@ -37,6 +37,7 @@ class TdConfig:
     default_project: str | None = None
     default_format: str | None = None  # "rich", "plain", or "json"
     default_sort: str = "priority"  # "priority", "due", "project", "created"
+    default_command: str = "today"  # "today", "ls", "inbox", "next"
     color: bool = True
     extra: dict[str, Any] = field(default_factory=dict)
 
@@ -57,6 +58,7 @@ def load_config() -> TdConfig:
         config.default_project = settings.get("default_project")
         config.default_format = settings.get("default_format")
         config.default_sort = settings.get("default_sort", "priority")
+        config.default_command = settings.get("default_command", "today")
         config.color = settings.get("color", True)
 
     # Env var overrides
@@ -68,6 +70,9 @@ def load_config() -> TdConfig:
 
     if sort := os.environ.get("TD_SORT"):
         config.default_sort = sort
+
+    if cmd := os.environ.get("TD_DEFAULT_CMD"):
+        config.default_command = cmd
 
     # Respect NO_COLOR (https://no-color.org/)
     if os.environ.get("NO_COLOR") is not None:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -183,6 +183,23 @@ class TestFocusCommand:
         assert data["type"] == "task_list"
 
 
+class TestDefaultCommand:
+    @patch("td.cli.tasks.get_client")
+    def test_no_subcommand_runs_today(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.filter_tasks.return_value = iter([[_mock_task()]])
+        api.get_projects.return_value = iter([[_mock_project()]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["type"] == "task_list"
+        api.filter_tasks.assert_called_once_with(query="overdue | today")
+
+
 class TestLsSortFlag:
     @patch("td.cli.tasks.get_client")
     def test_ls_with_sort(self, mock_gc: MagicMock) -> None:


### PR DESCRIPTION
## Summary
- `td` with no args now runs `td today` (the default command)
- Configurable via `default_command` in config.toml or `TD_DEFAULT_CMD` env var
- `td --help` still shows help as expected

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)