### PR TITLE
feat(add): support --section flag for task creation

### DIFF
--- a/src/td/cli/tasks.py
+++ b/src/td/cli/tasks.py
@@ -13,6 +13,7 @@ from td.core.cache import resolve_task_ref
 from td.core.client import get_client
 from td.core.config import load_config
 from td.core.projects import get_inbox_project, get_project_name_map, resolve_project
+from td.core.sections import resolve_section
 from td.core.tasks import (
     SORT_OPTIONS,
     complete_task,
@@ -92,6 +93,12 @@ def _read_stdin() -> str | None:
 @click.option("-l", "--label", "labels", multiple=True, help="Label (repeatable).")
 @click.option("--desc", "description", help="Task description.")
 @click.option(
+    "-s",
+    "--section",
+    "section_name",
+    help="Section name (requires --project).",
+)
+@click.option(
     "--idempotent",
     is_flag=True,
     help="Skip if identical task already exists.",
@@ -105,6 +112,7 @@ def add(
     due: str | None,
     labels: tuple[str, ...],
     description: str | None,
+    section_name: str | None,
     idempotent: bool,
 ) -> None:
     """Create a new task. Reads from stdin if no content argument."""
@@ -117,9 +125,19 @@ def add(
             suggestion="Provide content as an argument or pipe via stdin.",
         )
 
+    if section_name and not project_name:
+        raise TdValidationError(
+            "--section requires --project.",
+            suggestion="Specify a project with -p to use --section.",
+        )
+
     project_id = None
     if project_name:
         project_id = resolve_project(api, project_name).id
+
+    section_id = None
+    if section_name and project_id:
+        section_id = resolve_section(api, section_name, project_id=project_id).id
 
     # Todoist uses inverted priority: 4=urgent, 1=normal
     # We expose 1=urgent to users, map to API values
@@ -129,6 +147,7 @@ def add(
         api,
         text,
         project_id=project_id,
+        section_id=section_id,
         priority=api_priority,
         due_string=due,
         labels=list(labels) if labels else None,

--- a/tests/test_cli_extras.py
+++ b/tests/test_cli_extras.py
@@ -150,3 +150,38 @@ class TestAddWithProject:
         assert result.exit_code == 0
         _, kwargs = api.add_task.call_args
         assert kwargs["project_id"] == "p1"
+
+    @patch("td.cli.tasks.get_client")
+    def test_add_with_section(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+
+        proj = MagicMock()
+        proj.id = "p1"
+        proj.name = "Work"
+        proj.is_inbox_project = False
+        api.get_projects.return_value = iter([[proj]])
+
+        sec = MagicMock()
+        sec.id = "s1"
+        sec.name = "In Progress"
+        api.get_sections.return_value = iter([[sec]])
+
+        api.add_task.return_value = _mock_task()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "add", "Test", "-p", "Work", "-s", "In Progress"])
+
+        assert result.exit_code == 0
+        _, kwargs = api.add_task.call_args
+        assert kwargs["section_id"] == "s1"
+
+    @patch("td.cli.tasks.get_client")
+    def test_add_section_without_project_errors(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "add", "Test", "-s", "Backlog"])
+
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- `td add "Task" -p Work -s "In Progress"` places task in a section
- Section resolved case-insensitively within the project
- Errors with helpful message if `--section` used without `--project`

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)