### PR TITLE
feat: add td search command

### DIFF
--- a/src/td/cli/__init__.py
+++ b/src/td/cli/__init__.py
@@ -98,6 +98,7 @@ def _register_commands() -> None:
         ls,
         next_task,
         quick,
+        search,
         today,
         undo,
     )
@@ -118,6 +119,7 @@ def _register_commands() -> None:
     cli.add_command(quick)
     cli.add_command(capture)
     cli.add_command(undo)
+    cli.add_command(search)
     cli.add_command(projects)
     cli.add_command(project_add)
     cli.add_command(sections)

--- a/src/td/cli/tasks.py
+++ b/src/td/cli/tasks.py
@@ -482,3 +482,37 @@ def capture(ctx: click.Context, text: tuple[str, ...]) -> None:
 
     task, _ = create_task(api, " ".join(text))
     fmt.success(f"Captured: {task.content}", {"task_id": task.id})
+
+
+@click.command()
+@click.argument("query", nargs=-1, required=True)
+@click.option("-p", "--project", "project_name", help="Scope to a project.")
+@click.pass_context
+def search(ctx: click.Context, query: tuple[str, ...], project_name: str | None) -> None:
+    """Search tasks by keyword across all projects.
+
+    Example: td search deploy | td search "blog post" -p Work
+    """
+    api = get_client()
+    fmt = _get_formatter(ctx)
+
+    search_term = " ".join(query)
+    tasks = list_tasks(api, filter_query=f"search: {search_term}")
+
+    if project_name:
+        project_id = resolve_project(api, project_name).id
+        tasks = [t for t in tasks if t.project_id == project_id]
+
+    # Sort by relevance: exact match > starts-with > contains
+    lower = search_term.lower()
+
+    def relevance(t: object) -> int:
+        content = getattr(t, "content", "").lower()
+        if content == lower:
+            return 0
+        if content.startswith(lower):
+            return 1
+        return 2
+
+    tasks.sort(key=relevance)
+    fmt.task_list(tasks)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -38,6 +38,7 @@ class TestSchemaCommand:
             "log",
             "focus",
             "quick",
+            "search",
             "undo",
             "project-add",
             "projects",

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -272,6 +272,23 @@ class TestCliCommands:
         api.add_task_quick.assert_called_once_with("Buy milk tomorrow")
 
     @patch("td.cli.tasks.get_client")
+    def test_search_command(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.filter_tasks.return_value = iter(
+            [[_mock_task(content="Deploy v2"), _mock_task(content="Deploy v3")]]
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "search", "deploy"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["type"] == "task_list"
+        assert len(data["data"]) == 2
+        api.filter_tasks.assert_called_once_with(query="search: deploy")
+
+    @patch("td.cli.tasks.get_client")
     def test_add_idempotent(self, mock_gc: MagicMock) -> None:
         api = MagicMock()
         mock_gc.return_value = api


### PR DESCRIPTION
## Summary
- `td search <query>` searches task content using Todoist's `search:` filter
- Results sorted by relevance (exact match > starts-with > contains)
- `-p` flag to scope to a specific project
- All three output modes supported

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)