### PR TITLE
feat: add td move command

### DIFF
--- a/src/td/cli/__init__.py
+++ b/src/td/cli/__init__.py
@@ -96,6 +96,7 @@ def _register_commands() -> None:
         inbox,
         log,
         ls,
+        move,
         next_task,
         quick,
         search,
@@ -118,6 +119,7 @@ def _register_commands() -> None:
     cli.add_command(delete)
     cli.add_command(quick)
     cli.add_command(capture)
+    cli.add_command(move)
     cli.add_command(undo)
     cli.add_command(search)
     cli.add_command(projects)

--- a/src/td/cli/tasks.py
+++ b/src/td/cli/tasks.py
@@ -516,3 +516,24 @@ def search(ctx: click.Context, query: tuple[str, ...], project_name: str | None)
 
     tasks.sort(key=relevance)
     fmt.task_list(tasks)
+
+
+@click.command()
+@click.argument("task_ref", nargs=-1, required=True)
+@click.option("-p", "--project", "project_name", required=True, help="Target project.")
+@click.pass_context
+def move(ctx: click.Context, task_ref: tuple[str, ...], project_name: str) -> None:
+    """Move a task to a different project.
+
+    Examples: td move 1 -p Personal | td move buy milk -p Work
+    """
+    api = get_client()
+    fmt = _get_formatter(ctx)
+    task_id = _resolve_task(" ".join(task_ref), api)
+
+    project = resolve_project(api, project_name)
+    api.move_task(task_id, project_id=project.id)
+    fmt.success(
+        f"Moved task to {project.name}",
+        {"task_id": task_id, "project_id": project.id, "project_name": project.name},
+    )

--- a/tests/test_cli_extras.py
+++ b/tests/test_cli_extras.py
@@ -131,6 +131,28 @@ class TestErrorBoundary:
         assert result.exit_code == 1
 
 
+class TestMoveCommand:
+    @patch("td.cli.tasks.get_client")
+    def test_move_task(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+
+        proj = MagicMock()
+        proj.id = "p2"
+        proj.name = "Personal"
+        proj.is_inbox_project = False
+        api.get_projects.return_value = iter([[proj]])
+        api.move_task.return_value = True
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "move", "t1", "-p", "Personal"])
+
+        assert result.exit_code == 0
+        api.move_task.assert_called_once_with("t1", project_id="p2")
+        data = json.loads(result.output)
+        assert data["ok"] is True
+
+
 class TestAddWithProject:
     @patch("td.cli.tasks.get_client")
     def test_add_with_project_resolution(self, mock_gc: MagicMock) -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -37,6 +37,7 @@ class TestSchemaCommand:
             "next",
             "log",
             "focus",
+            "move",
             "quick",
             "search",
             "undo",


### PR DESCRIPTION
## Summary
- `td move <ref> -p <project>` moves a task to a different project
- Uses SDK's `move_task()` API
- Accepts row number, content match, or task ID

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)