### PR TITLE
feat: add td show command for full task details

### DIFF
--- a/src/td/cli/__init__.py
+++ b/src/td/cli/__init__.py
@@ -100,6 +100,7 @@ def _register_commands() -> None:
         next_task,
         quick,
         search,
+        show,
         today,
         undo,
     )
@@ -120,6 +121,7 @@ def _register_commands() -> None:
     cli.add_command(quick)
     cli.add_command(capture)
     cli.add_command(move)
+    cli.add_command(show)
     cli.add_command(undo)
     cli.add_command(search)
     cli.add_command(projects)

--- a/src/td/cli/output.py
+++ b/src/td/cli/output.py
@@ -111,6 +111,54 @@ class OutputFormatter:
         else:
             self._rich_task(task)
 
+    def task_detail(self, task: Task, project_name: str | None = None) -> None:
+        """Render full task details."""
+        if self.mode == OutputMode.JSON:
+            d = _task_to_dict(task)
+            if project_name:
+                d["project_name"] = project_name
+            self._json_out(d, "task")
+        elif self.mode == OutputMode.PLAIN:
+            click.echo(f"ID\t{task.id}")
+            click.echo(f"Content\t{task.content}")
+            if task.description:
+                click.echo(f"Description\t{task.description}")
+            if project_name:
+                click.echo(f"Project\t{project_name}")
+            p_label = f"p{5 - task.priority}" if task.priority else ""
+            click.echo(f"Priority\t{p_label}")
+            click.echo(f"Due\t{task.due.string if task.due else ''}")
+            if task.labels:
+                click.echo(f"Labels\t{', '.join(task.labels)}")
+        else:
+            self._rich_task_detail(task, project_name)
+
+    def _rich_task_detail(self, task: Task, project_name: str | None = None) -> None:
+        assert self._console is not None
+        from rich.panel import Panel
+
+        p_label, p_style = _PRIORITY_STYLES.get(task.priority, ("p4", "dim"))
+        lines: list[str] = []
+        if project_name:
+            lines.append(f"[dim]Project:[/dim]  {project_name}")
+        lines.append(f"[dim]Priority:[/dim] [{p_style}]{p_label}[/{p_style}]")
+        if task.due:
+            lines.append(f"[dim]Due:[/dim]      [yellow]{task.due.string}[/yellow]")
+        if task.labels:
+            lbl_str = ", ".join(f"[cyan]@{lbl}[/cyan]" for lbl in task.labels)
+            lines.append(f"[dim]Labels:[/dim]   {lbl_str}")
+        if task.description:
+            lines.append(f"\n{task.description}")
+        lines.append(f"\n[dim]ID: {task.id}[/dim]")
+
+        self._console.print(
+            Panel(
+                "\n".join(lines),
+                title=f"[bold]{task.content}[/bold]",
+                expand=False,
+            )
+        )
+
     def task_list(
         self,
         tasks: list[Task],

--- a/src/td/cli/tasks.py
+++ b/src/td/cli/tasks.py
@@ -12,7 +12,12 @@ from td.cli.output import OutputFormatter
 from td.core.cache import resolve_task_ref
 from td.core.client import get_client
 from td.core.config import load_config
-from td.core.projects import get_inbox_project, get_project_name_map, resolve_project
+from td.core.projects import (
+    _collect_projects,
+    get_inbox_project,
+    get_project_name_map,
+    resolve_project,
+)
 from td.core.sections import resolve_section
 from td.core.tasks import (
     SORT_OPTIONS,
@@ -481,6 +486,26 @@ def quick(ctx: click.Context, text: tuple[str, ...]) -> None:
 
     task = quick_add(api, content)
     fmt.item_created("task", task)
+
+
+@click.command()
+@click.argument("task_ref", nargs=-1, required=True)
+@click.pass_context
+def show(ctx: click.Context, task_ref: tuple[str, ...]) -> None:
+    """View full task details. Accepts row number, content match, or task ID.
+
+    Examples: td show 1 | td show buy milk | td show 8bx9a0c2
+    """
+    api = get_client()
+    fmt = _get_formatter(ctx)
+    task_id = _resolve_task(" ".join(task_ref), api)
+
+    task = api.get_task(task_id)
+    project_name: str | None = None
+    if task.project_id:
+        projects = {p.id: p.name for p in _collect_projects(api)}
+        project_name = projects.get(task.project_id)
+    fmt.task_detail(task, project_name=project_name)
 
 
 @click.command()

--- a/tests/test_cli_extras.py
+++ b/tests/test_cli_extras.py
@@ -28,6 +28,31 @@ def _mock_task(**overrides: object) -> MagicMock:
     return task
 
 
+class TestShowCommand:
+    @patch("td.cli.tasks.get_client")
+    def test_show_task(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        task = _mock_task(content="Buy milk", description="Whole milk from store")
+        api.get_task.return_value = task
+        # For project name resolution
+        proj = MagicMock()
+        proj.id = "p1"
+        proj.name = "Personal"
+        proj.is_inbox_project = False
+        proj.to_dict.return_value = {"id": "p1", "name": "Personal"}
+        api.get_projects.return_value = iter([[proj]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "show", "t1"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["data"]["content"] == "Buy milk"
+        api.get_task.assert_called_once_with("t1")
+
+
 class TestEditCommand:
     @patch("td.cli.tasks.get_client")
     def test_edit_task(self, mock_gc: MagicMock) -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -40,6 +40,7 @@ class TestSchemaCommand:
             "move",
             "quick",
             "search",
+            "show",
             "undo",
             "project-add",
             "projects",


### PR DESCRIPTION
## Summary
- `td show <ref>` displays full task details (content, description, project, priority, due, labels)
- Rich mode: panel layout with styled fields
- JSON mode: full task dict with `project_name`
- Plain mode: tab-separated key-value pairs
- Accepts row number, content match, or task ID

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)