### PR TITLE
feat: add td comment and td comments commands

### DIFF
--- a/src/td/cli/__init__.py
+++ b/src/td/cli/__init__.py
@@ -81,6 +81,7 @@ def cli(ctx: click.Context, output_json: bool, plain: bool, debug: bool) -> None
 
 # Register subcommands (imported here to avoid circular imports)
 def _register_commands() -> None:
+    from td.cli.comments import comment, comments
     from td.cli.config_cmd import completions, init
     from td.cli.labels import label_add, labels
     from td.cli.projects import project_add, projects
@@ -107,6 +108,8 @@ def _register_commands() -> None:
 
     cli.add_command(init)
     cli.add_command(completions)
+    cli.add_command(comment)
+    cli.add_command(comments)
     cli.add_command(schema)
     cli.add_command(add)
     cli.add_command(ls)

--- a/src/td/cli/comments.py
+++ b/src/td/cli/comments.py
@@ -1,0 +1,76 @@
+"""Comments CLI commands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from td.cli.output import OutputFormatter
+from td.core.client import get_client
+
+
+def _get_formatter(ctx: click.Context) -> OutputFormatter:
+    return ctx.obj["formatter"]  # type: ignore[no-any-return]
+
+
+def _resolve_task_ref(ref: str, api: Any) -> str:
+    """Import and call the shared task resolver."""
+    from td.cli.tasks import _resolve_task
+
+    return _resolve_task(ref, api)
+
+
+@click.command()
+@click.argument("task_ref")
+@click.argument("text", nargs=-1, required=True)
+@click.pass_context
+def comment(ctx: click.Context, task_ref: str, text: tuple[str, ...]) -> None:
+    """Add a comment to a task.
+
+    Examples: td comment 1 "Picked up 2%, not whole"
+    """
+    api = get_client()
+    fmt = _get_formatter(ctx)
+    task_id = _resolve_task_ref(task_ref, api)
+
+    result = api.add_comment(content=" ".join(text), task_id=task_id)
+    fmt.success(
+        f"Comment added to task {task_id}",
+        {"comment_id": result.id, "task_id": task_id, "content": result.content},
+    )
+
+
+@click.command()
+@click.argument("task_ref")
+@click.pass_context
+def comments(ctx: click.Context, task_ref: str) -> None:
+    """List comments on a task.
+
+    Examples: td comments 1 | td comments buy milk
+    """
+    api = get_client()
+    fmt = _get_formatter(ctx)
+    task_id = _resolve_task_ref(task_ref, api)
+
+    all_comments = [c for page in api.get_comments(task_id=task_id) for c in page]
+
+    if fmt.mode.value == "json":
+        fmt._json_out([c.to_dict() for c in all_comments], "comment_list")
+    elif fmt.mode.value == "plain":
+        click.echo("ID\tCONTENT\tPOSTED")
+        for c in all_comments:
+            click.echo(f"{c.id}\t{c.content}\t{c.posted_at}")
+    else:
+        assert fmt._console is not None
+        from rich.table import Table
+
+        table = Table(title="Comments", show_lines=False)
+        table.add_column("Content", style="bold")
+        table.add_column("Posted", style="dim")
+        table.add_column("ID", style="dim")
+
+        for c in all_comments:
+            table.add_row(c.content, str(c.posted_at), c.id)
+
+        fmt._console.print(table)

--- a/tests/test_cli_extras.py
+++ b/tests/test_cli_extras.py
@@ -35,7 +35,6 @@ class TestShowCommand:
         mock_gc.return_value = api
         task = _mock_task(content="Buy milk", description="Whole milk from store")
         api.get_task.return_value = task
-        # For project name resolution
         proj = MagicMock()
         proj.id = "p1"
         proj.name = "Personal"
@@ -51,6 +50,45 @@ class TestShowCommand:
         assert data["ok"] is True
         assert data["data"]["content"] == "Buy milk"
         api.get_task.assert_called_once_with("t1")
+
+
+class TestCommentCommand:
+    @patch("td.cli.comments.get_client")
+    def test_add_comment(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        comment_obj = MagicMock()
+        comment_obj.id = "c1"
+        comment_obj.content = "Test comment"
+        api.add_comment.return_value = comment_obj
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "comment", "t1", "Test", "comment"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["data"]["comment_id"] == "c1"
+        api.add_comment.assert_called_once_with(content="Test comment", task_id="t1")
+
+    @patch("td.cli.comments.get_client")
+    def test_list_comments(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        c1 = MagicMock()
+        c1.id = "c1"
+        c1.content = "First"
+        c1.posted_at = "2026-03-25"
+        c1.to_dict.return_value = {"id": "c1", "content": "First", "posted_at": "2026-03-25"}
+        api.get_comments.return_value = iter([[c1]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "comments", "t1"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["type"] == "comment_list"
+        assert len(data["data"]) == 1
 
 
 class TestEditCommand:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -28,6 +28,8 @@ class TestSchemaCommand:
         expected = {
             "add",
             "capture",
+            "comment",
+            "comments",
             "ls",
             "done",
             "edit",


### PR DESCRIPTION
## Summary
- `td comment <ref> <text>` adds a comment to a task
- `td comments <ref>` lists comments on a task
- Both accept row number, content match, or task ID
- All three output modes supported

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)