### PR TITLE
feat: rate limit awareness and tracking

### DIFF
--- a/src/td/cli/__init__.py
+++ b/src/td/cli/__init__.py
@@ -85,6 +85,7 @@ def _register_commands() -> None:
     from td.cli.config_cmd import completions, init
     from td.cli.labels import label_add, labels
     from td.cli.projects import project_add, projects
+    from td.cli.rate_limit import rate_limit
     from td.cli.schema_cmd import schema
     from td.cli.sections import section_add, sections
     from td.cli.tasks import (
@@ -133,6 +134,7 @@ def _register_commands() -> None:
     cli.add_command(section_add)
     cli.add_command(labels)
     cli.add_command(label_add)
+    cli.add_command(rate_limit)
 
 
 _register_commands()

--- a/src/td/cli/rate_limit.py
+++ b/src/td/cli/rate_limit.py
@@ -1,0 +1,44 @@
+"""Rate limit CLI command."""
+
+from __future__ import annotations
+
+import click
+
+from td.cli.output import OutputFormatter
+from td.core.rate_limit import load_rate_limit_cache
+
+
+def _get_formatter(ctx: click.Context) -> OutputFormatter:
+    return ctx.obj["formatter"]  # type: ignore[no-any-return]
+
+
+@click.command(name="rate-limit")
+@click.pass_context
+def rate_limit(ctx: click.Context) -> None:
+    """Show current API rate limit status from cached response headers."""
+    fmt = _get_formatter(ctx)
+    data = load_rate_limit_cache()
+
+    remaining = data["remaining"]
+    limit = data["limit"]
+
+    if remaining is None:
+        fmt.success("No rate limit data cached yet. Run any command first.")
+        return
+
+    assert limit is not None
+    pct = (remaining / limit * 100) if limit > 0 else 0
+
+    if fmt.mode.value == "json":
+        fmt._json_out(
+            {"remaining": remaining, "limit": limit, "percent_remaining": round(pct, 1)},
+            "rate_limit",
+        )
+    elif fmt.mode.value == "plain":
+        click.echo(f"{remaining}\t{limit}\t{pct:.1f}%")
+    else:
+        assert fmt._console is not None
+        style = "green" if pct > 50 else ("yellow" if pct > 20 else "red bold")
+        fmt._console.print(
+            f"API rate limit: [{style}]{remaining}/{limit}[/{style}] ({pct:.0f}% remaining)"
+        )

--- a/src/td/core/client.py
+++ b/src/td/core/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from todoist_api_python.api import TodoistAPI
 
 from td.core.config import resolve_token
+from td.core.rate_limit import create_monitored_session
 
 
 class TdAuthError(Exception):
@@ -18,8 +19,9 @@ def get_client() -> TodoistAPI:
     """Construct a TodoistAPI client from the resolved token.
 
     Raises TdAuthError if no token is available.
+    Uses a monitored session to capture rate limit headers.
     """
     token = resolve_token()
     if not token:
         raise TdAuthError
-    return TodoistAPI(token)
+    return TodoistAPI(token, session=create_monitored_session())

--- a/src/td/core/rate_limit.py
+++ b/src/td/core/rate_limit.py
@@ -1,0 +1,106 @@
+"""Rate limit monitoring via requests session hooks."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_WARN_THRESHOLD = 0.20  # warn when < 20% remaining
+
+
+def _cache_path() -> Path:
+    """Path to the rate limit cache file."""
+    import os
+
+    xdg_cache = os.environ.get("XDG_CACHE_HOME", "")
+    cache_dir = Path(xdg_cache) / "td" if xdg_cache else Path.home() / ".cache" / "td"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / "rate_limit.json"
+
+
+class RateLimitMonitor:
+    """Captures rate limit headers from API responses."""
+
+    def __init__(self) -> None:
+        self.remaining: int | None = None
+        self.limit: int | None = None
+
+    def hook(self, response: requests.Response, **kwargs: Any) -> None:
+        """requests response hook — called after every API response."""
+        raw_remaining = response.headers.get("X-Ratelimit-Remaining")
+        raw_limit = response.headers.get("X-Ratelimit-Limit")
+
+        if raw_remaining is not None:
+            self.remaining = int(raw_remaining)
+        if raw_limit is not None:
+            self.limit = int(raw_limit)
+
+        # Debug logging
+        if self.remaining is not None and self.limit is not None:
+            logger.debug(
+                "API %s (%d/%d remaining)", response.status_code, self.remaining, self.limit
+            )
+
+        # Warn on stderr if approaching limit
+        if (
+            self.remaining is not None
+            and self.limit is not None
+            and self.limit > 0
+            and (self.remaining / self.limit) < _WARN_THRESHOLD
+        ):
+            print(
+                f"Warning: {self.remaining}/{self.limit} API calls remaining",
+                file=sys.stderr,
+            )
+
+        # Persist to cache
+        self._save_cache()
+
+    def _save_cache(self) -> None:
+        """Persist current rate limit state to disk."""
+        if self.remaining is None:
+            return
+        try:
+            path = _cache_path()
+            data = {"remaining": self.remaining, "limit": self.limit}
+            path.write_text(json.dumps(data))
+        except Exception:
+            pass
+
+
+def load_rate_limit_cache() -> dict[str, int | None]:
+    """Load cached rate limit data. Returns {remaining, limit}."""
+    try:
+        path = _cache_path()
+        if path.exists():
+            data = json.loads(path.read_text())
+            return {
+                "remaining": data.get("remaining"),
+                "limit": data.get("limit"),
+            }
+    except Exception:
+        pass
+    return {"remaining": None, "limit": None}
+
+
+# Singleton monitor — shared across the session
+_monitor = RateLimitMonitor()
+
+
+def get_monitor() -> RateLimitMonitor:
+    """Get the global rate limit monitor."""
+    return _monitor
+
+
+def create_monitored_session() -> requests.Session:
+    """Create a requests.Session with rate limit monitoring."""
+    session = requests.Session()
+    session.hooks["response"].append(_monitor.hook)
+    return session

--- a/tests/test_cli_extras.py
+++ b/tests/test_cli_extras.py
@@ -91,6 +91,44 @@ class TestCommentCommand:
         assert len(data["data"]) == 1
 
 
+class TestRateLimitMonitor:
+    def test_hook_captures_headers(self) -> None:
+        from td.core.rate_limit import RateLimitMonitor
+
+        monitor = RateLimitMonitor()
+        response = MagicMock()
+        response.headers = {"X-Ratelimit-Remaining": "400", "X-Ratelimit-Limit": "450"}
+        response.status_code = 200
+
+        monitor.hook(response)
+
+        assert monitor.remaining == 400
+        assert monitor.limit == 450
+
+    @patch("td.cli.rate_limit.load_rate_limit_cache")
+    def test_rate_limit_command(self, mock_cache: MagicMock) -> None:
+        mock_cache.return_value = {"remaining": 380, "limit": 450}
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "rate-limit"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["data"]["remaining"] == 380
+        assert data["data"]["limit"] == 450
+
+    @patch("td.cli.rate_limit.load_rate_limit_cache")
+    def test_rate_limit_no_data(self, mock_cache: MagicMock) -> None:
+        mock_cache.return_value = {"remaining": None, "limit": None}
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "rate-limit"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["type"] == "success"
+
+
 class TestEditCommand:
     @patch("td.cli.tasks.get_client")
     def test_edit_task(self, mock_gc: MagicMock) -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -50,6 +50,7 @@ class TestSchemaCommand:
             "section-add",
             "labels",
             "label-add",
+            "rate-limit",
             "init",
             "completions",
             "schema",


### PR DESCRIPTION
## Summary
All three levels from the issue:

1. **Debug output**: `DEBUG: API 200 (380/450 remaining)` via `--debug`
2. **Proactive warning**: stderr warning when < 20% remaining
3. **Status command**: `td rate-limit` reads from cache — no API call needed

Implementation uses `requests.Session` response hooks injected into the Todoist SDK via its `session=` parameter. No monkeypatching, survives SDK upgrades.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)