### PR TITLE
fix(docs): update install instructions to current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@
 ## Install
 
 ```bash
-pip install todoist-cli
+git clone https://github.com/craigmccaskill/todoist-cli.git
+cd todoist-cli
+pip install -e .
 ```
 
-Requires Python 3.10+.
+Requires Python 3.10+. PyPI package coming soon.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Replaced `pip install todoist-cli` with clone + install from source
- Added "PyPI package coming soon" note
- Package isn't on PyPI yet — README should reflect reality

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)