### PR TITLE
feat(tui): add textual-based picker infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=8",
+    "pytest-asyncio",
     "pytest-cov",
     "pytest-mock",
 ]
@@ -45,8 +46,11 @@ lint = [
     "mypy",
     "types-requests",
 ]
+interactive = [
+    "textual>=0.50",
+]
 dev = [
-    "todoist-cli[test,lint]",
+    "todoist-cli[test,lint,interactive]",
     "pre-commit",
 ]
 

--- a/src/td/tui/__init__.py
+++ b/src/td/tui/__init__.py
@@ -1,0 +1,13 @@
+"""TUI components for interactive task management."""
+
+from __future__ import annotations
+
+
+def is_available() -> bool:
+    """Check if textual is installed."""
+    try:
+        import textual  # noqa: F401
+
+        return True
+    except ImportError:
+        return False

--- a/src/td/tui/picker.py
+++ b/src/td/tui/picker.py
@@ -1,0 +1,96 @@
+"""Select-mode picker — choose one item from a list."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from textual import on
+from textual.app import App, ComposeResult
+from textual.binding import Binding, BindingType
+from textual.widgets import DataTable, Static
+
+
+class PickerApp(App[str | None]):
+    """Generic picker app — displays a table, returns the selected item's key."""
+
+    CSS = """
+    Screen {
+        layout: vertical;
+    }
+    #title {
+        text-align: center;
+        padding: 1 0;
+        color: $text-muted;
+    }
+    #hint {
+        text-align: center;
+        padding: 1 0;
+        color: $text-muted;
+    }
+    DataTable {
+        height: auto;
+        max-height: 20;
+    }
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("enter", "select", "Select"),
+        Binding("slash", "filter", "Filter"),
+    ]
+
+    def __init__(
+        self,
+        title: str,
+        columns: list[str],
+        rows: list[dict[str, Any]],
+        key_field: str = "id",
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._columns = columns
+        self._rows = rows
+        self._key_field = key_field
+        self._all_rows = rows
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._title, id="title")
+        table: DataTable[str] = DataTable(cursor_type="row")
+        for col in self._columns:
+            table.add_column(col, key=col)
+        for row in self._rows:
+            table.add_row(
+                *[str(row.get(col, "")) for col in self._columns],
+                key=str(row[self._key_field]),
+            )
+        yield table
+        yield Static(
+            "↑/↓ navigate · enter select · esc cancel",
+            id="hint",
+        )
+
+    def action_select(self) -> None:
+        table = self.query_one(DataTable)
+        if table.row_count > 0:
+            row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
+            self.exit(str(row_key))
+        else:
+            self.exit(None)
+
+    def action_cancel(self) -> None:
+        self.exit(None)
+
+    @on(DataTable.RowSelected)
+    def on_row_selected(self, event: DataTable.RowSelected) -> None:
+        self.exit(str(event.row_key.value))
+
+
+def pick_from_list(
+    title: str,
+    columns: list[str],
+    rows: list[dict[str, Any]],
+    key_field: str = "id",
+) -> str | None:
+    """Show a picker and return the selected key, or None if cancelled."""
+    app = PickerApp(title, columns, rows, key_field)
+    return app.run()

--- a/src/td/tui/pickers.py
+++ b/src/td/tui/pickers.py
@@ -1,0 +1,70 @@
+"""Domain-specific pickers built on the generic picker."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from todoist_api_python.models import Label, Project, Section, Task
+
+from td.tui.picker import pick_from_list
+
+# --- Priority mapping (same as cli/output.py) ---
+_PRIORITY_LABELS = {4: "p1", 3: "p2", 2: "p3", 1: "p4"}
+
+
+def pick_task(tasks: list[Task], title: str = "Select a task") -> str | None:
+    """Show a task picker. Returns task ID or None."""
+    rows: list[dict[str, Any]] = []
+    for i, t in enumerate(tasks, 1):
+        rows.append(
+            {
+                "id": t.id,
+                "#": str(i),
+                "Pri": _PRIORITY_LABELS.get(t.priority, "p4"),
+                "Content": t.content,
+                "Due": t.due.string if t.due else "",
+                "Labels": ", ".join(f"@{lbl}" for lbl in t.labels) if t.labels else "",
+            }
+        )
+    return pick_from_list(
+        title,
+        columns=["#", "Pri", "Content", "Due", "Labels"],
+        rows=rows,
+    )
+
+
+def pick_project(projects: list[Project], title: str = "Select a project") -> str | None:
+    """Show a project picker. Returns project ID or None."""
+    rows: list[dict[str, Any]] = []
+    for p in projects:
+        fav = "★" if p.is_favorite else ""
+        rows.append({"id": p.id, "Name": p.name, " ": fav})
+    return pick_from_list(title, columns=["Name", " "], rows=rows)
+
+
+def pick_label(labels: list[Label], title: str = "Select a label") -> str | None:
+    """Show a label picker. Returns label name or None."""
+    rows: list[dict[str, Any]] = []
+    for lbl in labels:
+        rows.append({"id": lbl.name, "Name": f"@{lbl.name}"})
+    return pick_from_list(title, columns=["Name"], rows=rows)
+
+
+def pick_section(sections: list[Section], title: str = "Select a section") -> str | None:
+    """Show a section picker. Returns section ID or None."""
+    rows: list[dict[str, Any]] = []
+    for s in sections:
+        rows.append({"id": s.id, "Name": s.name})
+    return pick_from_list(title, columns=["Name"], rows=rows)
+
+
+def pick_priority(title: str = "Select priority") -> int | None:
+    """Show a priority picker. Returns API priority value (4=urgent) or None."""
+    rows = [
+        {"id": "4", "Priority": "p1 — Urgent"},
+        {"id": "3", "Priority": "p2 — High"},
+        {"id": "2", "Priority": "p3 — Medium"},
+        {"id": "1", "Priority": "p4 — Low"},
+    ]
+    result = pick_from_list(title, columns=["Priority"], rows=rows)
+    return int(result) if result else None

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,105 @@
+"""Tests for TUI infrastructure."""
+
+from __future__ import annotations
+
+import pytest
+
+from td.tui import is_available
+
+
+class TestTuiAvailability:
+    def test_is_available(self) -> None:
+        assert is_available() is True
+
+    def test_picker_imports(self) -> None:
+        from td.tui.picker import PickerApp, pick_from_list
+
+        assert PickerApp is not None
+        assert pick_from_list is not None
+
+    def test_domain_pickers_import(self) -> None:
+        from td.tui.pickers import (
+            pick_label,
+            pick_priority,
+            pick_project,
+            pick_section,
+            pick_task,
+        )
+
+        assert pick_task is not None
+        assert pick_project is not None
+        assert pick_label is not None
+        assert pick_section is not None
+        assert pick_priority is not None
+
+
+class TestPickerApp:
+    @pytest.mark.asyncio
+    async def test_picker_app_creates(self) -> None:
+        """Verify PickerApp can be instantiated with test data."""
+        from td.tui.picker import PickerApp
+
+        app = PickerApp(
+            title="Test",
+            columns=["Name", "Value"],
+            rows=[
+                {"id": "1", "Name": "Alpha", "Value": "100"},
+                {"id": "2", "Name": "Beta", "Value": "200"},
+            ],
+        )
+        assert app is not None
+
+    @pytest.mark.asyncio
+    async def test_picker_app_cancel(self) -> None:
+        """Verify cancel returns None."""
+        from textual.pilot import Pilot
+
+        from td.tui.picker import PickerApp
+
+        app = PickerApp(
+            title="Test",
+            columns=["Name"],
+            rows=[{"id": "1", "Name": "Alpha"}],
+        )
+        async with app.run_test() as pilot:
+            assert isinstance(pilot, Pilot)
+            await pilot.press("escape")
+
+        assert app.return_value is None
+
+    @pytest.mark.asyncio
+    async def test_picker_app_select(self) -> None:
+        """Verify enter returns the selected key."""
+        from td.tui.picker import PickerApp
+
+        app = PickerApp(
+            title="Test",
+            columns=["Name"],
+            rows=[
+                {"id": "first", "Name": "Alpha"},
+                {"id": "second", "Name": "Beta"},
+            ],
+        )
+        async with app.run_test() as pilot:
+            await pilot.press("enter")
+
+        assert app.return_value == "first"
+
+    @pytest.mark.asyncio
+    async def test_picker_app_navigate_and_select(self) -> None:
+        """Verify navigating down then selecting returns second row."""
+        from td.tui.picker import PickerApp
+
+        app = PickerApp(
+            title="Test",
+            columns=["Name"],
+            rows=[
+                {"id": "first", "Name": "Alpha"},
+                {"id": "second", "Name": "Beta"},
+            ],
+        )
+        async with app.run_test() as pilot:
+            await pilot.press("down")
+            await pilot.press("enter")
+
+        assert app.return_value == "second"


### PR DESCRIPTION
## Summary
- Generic `PickerApp` built on textual's `DataTable` with row cursor navigation
- Domain-specific pickers: task, project, label, section, priority
- `textual` added as optional dep: `pip install todoist-cli[interactive]`
- `is_available()` check for graceful fallback
- 7 new tests including async textual pilot tests

Part of #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)