### PR TITLE
feat(tui): wire interactive pickers into task commands

### DIFF
--- a/src/td/cli/comments.py
+++ b/src/td/cli/comments.py
@@ -14,25 +14,25 @@ def _get_formatter(ctx: click.Context) -> OutputFormatter:
     return ctx.obj["formatter"]  # type: ignore[no-any-return]
 
 
-def _resolve_task_ref(ref: str, api: Any) -> str:
-    """Import and call the shared task resolver."""
-    from td.cli.tasks import _resolve_task
+def _require_task(ref: str | None, api: Any) -> str:
+    """Resolve task ref, launching picker if empty and TTY."""
+    from td.cli.tasks import _require_task_ref
 
-    return _resolve_task(ref, api)
+    return _require_task_ref((ref,) if ref else (), api)
 
 
 @click.command()
-@click.argument("task_ref")
+@click.argument("task_ref", required=False, default=None)
 @click.argument("text", nargs=-1, required=True)
 @click.pass_context
-def comment(ctx: click.Context, task_ref: str, text: tuple[str, ...]) -> None:
+def comment(ctx: click.Context, task_ref: str | None, text: tuple[str, ...]) -> None:
     """Add a comment to a task.
 
     Examples: td comment 1 "Picked up 2%, not whole"
     """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task_ref(task_ref, api)
+    task_id = _require_task(task_ref, api)
 
     result = api.add_comment(content=" ".join(text), task_id=task_id)
     fmt.success(
@@ -42,16 +42,16 @@ def comment(ctx: click.Context, task_ref: str, text: tuple[str, ...]) -> None:
 
 
 @click.command()
-@click.argument("task_ref")
+@click.argument("task_ref", required=False, default=None)
 @click.pass_context
-def comments(ctx: click.Context, task_ref: str) -> None:
+def comments(ctx: click.Context, task_ref: str | None) -> None:
     """List comments on a task.
 
     Examples: td comments 1 | td comments buy milk
     """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task_ref(task_ref, api)
+    task_id = _require_task(task_ref, api)
 
     all_comments = [c for page in api.get_comments(task_id=task_id) for c in page]
 

--- a/src/td/cli/tasks.py
+++ b/src/td/cli/tasks.py
@@ -86,6 +86,42 @@ def _read_stdin() -> str | None:
     return None
 
 
+def _pick_task_interactive(api: Any) -> str | None:
+    """Launch task picker if textual is available, return task ID or None."""
+    from td.tui import is_available
+
+    if not is_available() or not sys.stdout.isatty():
+        return None
+
+    tasks = list_tasks(api, filter_query="overdue | today")
+    if not tasks:
+        tasks_all = list_tasks(api)
+        tasks = tasks_all
+
+    if not tasks:
+        return None
+
+    from td.tui.pickers import pick_task
+
+    return pick_task(tasks)
+
+
+def _require_task_ref(task_ref: tuple[str, ...], api: Any) -> str:
+    """Resolve task ref, launching picker if empty and TTY."""
+    ref = " ".join(task_ref)
+    if ref:
+        return _resolve_task(ref, api)
+
+    picked = _pick_task_interactive(api)
+    if picked:
+        return picked
+
+    raise TdValidationError(
+        "No task specified.",
+        suggestion="Provide a row number, content match, or task ID.",
+    )
+
+
 @click.command()
 @click.argument("content", nargs=-1)
 @click.option("-p", "--project", "project_name", help="Project name or ID.")
@@ -351,7 +387,7 @@ def _is_fuzzy_ref(ref: str) -> bool:
 
 
 @click.command()
-@click.argument("task_ref", nargs=-1, required=True)
+@click.argument("task_ref", nargs=-1)
 @click.option("-y", "--yes", is_flag=True, help="Skip confirmation on fuzzy match.")
 @click.pass_context
 def done(ctx: click.Context, task_ref: tuple[str, ...], yes: bool) -> None:
@@ -362,7 +398,7 @@ def done(ctx: click.Context, task_ref: tuple[str, ...], yes: bool) -> None:
     api = get_client()
     fmt = _get_formatter(ctx)
     ref = " ".join(task_ref)
-    task_id = _resolve_task(ref, api)
+    task_id = _require_task_ref(task_ref, api)
 
     # Confirm on fuzzy match in TTY mode
     if _is_fuzzy_ref(ref) and not yes and sys.stdout.isatty():
@@ -376,7 +412,7 @@ def done(ctx: click.Context, task_ref: tuple[str, ...], yes: bool) -> None:
 
 
 @click.command()
-@click.argument("task_ref", nargs=-1, required=True)
+@click.argument("task_ref", nargs=-1)
 @click.pass_context
 def undo(ctx: click.Context, task_ref: tuple[str, ...]) -> None:
     """Reopen a completed task. Accepts row number, content match, or task ID.
@@ -385,14 +421,14 @@ def undo(ctx: click.Context, task_ref: tuple[str, ...]) -> None:
     """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task(" ".join(task_ref), api)
+    task_id = _require_task_ref(task_ref, api)
 
     uncomplete_task(api, task_id)
     fmt.success(f"Reopened task {task_id}", {"task_id": task_id})
 
 
 @click.command()
-@click.argument("task_ref", nargs=-1, required=True)
+@click.argument("task_ref", nargs=-1)
 @click.option("--content", help="New content.")
 @click.option(
     "--priority",
@@ -418,7 +454,7 @@ def edit(
     """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task(" ".join(task_ref), api)
+    task_id = _require_task_ref(task_ref, api)
 
     # No flags provided — show current task values
     has_updates = content or priority or due or labels or description
@@ -442,7 +478,7 @@ def edit(
 
 
 @click.command()
-@click.argument("task_ref", nargs=-1, required=True)
+@click.argument("task_ref", nargs=-1)
 @click.option("-y", "--yes", is_flag=True, help="Skip confirmation.")
 @click.pass_context
 def delete(ctx: click.Context, task_ref: tuple[str, ...], yes: bool) -> None:
@@ -452,7 +488,7 @@ def delete(ctx: click.Context, task_ref: tuple[str, ...], yes: bool) -> None:
     """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task(" ".join(task_ref), api)
+    task_id = _require_task_ref(task_ref, api)
     if not yes:
         if not sys.stdout.isatty():
             raise TdValidationError(
@@ -489,7 +525,7 @@ def quick(ctx: click.Context, text: tuple[str, ...]) -> None:
 
 
 @click.command()
-@click.argument("task_ref", nargs=-1, required=True)
+@click.argument("task_ref", nargs=-1)
 @click.pass_context
 def show(ctx: click.Context, task_ref: tuple[str, ...]) -> None:
     """View full task details. Accepts row number, content match, or task ID.
@@ -498,7 +534,7 @@ def show(ctx: click.Context, task_ref: tuple[str, ...]) -> None:
     """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task(" ".join(task_ref), api)
+    task_id = _require_task_ref(task_ref, api)
 
     task = api.get_task(task_id)
     project_name: str | None = None
@@ -558,7 +594,7 @@ def search(ctx: click.Context, query: tuple[str, ...], project_name: str | None)
 
 
 @click.command()
-@click.argument("task_ref", nargs=-1, required=True)
+@click.argument("task_ref", nargs=-1)
 @click.option("-p", "--project", "project_name", required=True, help="Target project.")
 @click.pass_context
 def move(ctx: click.Context, task_ref: tuple[str, ...], project_name: str) -> None:
@@ -568,7 +604,7 @@ def move(ctx: click.Context, task_ref: tuple[str, ...], project_name: str) -> No
     """
     api = get_client()
     fmt = _get_formatter(ctx)
-    task_id = _resolve_task(" ".join(task_ref), api)
+    task_id = _require_task_ref(task_ref, api)
 
     project = resolve_project(api, project_name)
     api.move_task(task_id, project_id=project.id)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from td.tui import is_available
@@ -103,3 +105,35 @@ class TestPickerApp:
             await pilot.press("enter")
 
         assert app.return_value == "second"
+
+
+class TestSelectModeFallback:
+    """Test that commands error properly when no ref given in non-TTY."""
+
+    @patch("td.cli.tasks.get_client")
+    def test_done_no_ref_non_tty_errors(self, mock_gc: MagicMock) -> None:
+        from click.testing import CliRunner
+
+        from td.cli import cli
+
+        api = MagicMock()
+        mock_gc.return_value = api
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "done"])
+
+        assert result.exit_code == 1
+
+    @patch("td.cli.tasks.get_client")
+    def test_show_no_ref_non_tty_errors(self, mock_gc: MagicMock) -> None:
+        from click.testing import CliRunner
+
+        from td.cli import cli
+
+        api = MagicMock()
+        mock_gc.return_value = api
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "show"])
+
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- Task commands (`done`, `show`, `edit`, `delete`, `undo`, `move`, `comment`, `comments`) now accept optional task ref
- When called with no args in TTY mode, launches the textual task picker
- Non-TTY mode returns structured error with suggestion
- Uses `_require_task_ref()` helper for consistent behavior across all commands

**Base branch**: `feat/tui-infrastructure` (depends on PR #102)

Part of #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)