### PR TITLE
feat: add documentation site with mkdocs-material

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: pip install mkdocs-material mkdocs-click
+      - run: mkdocs build --strict
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage.xml
 htmlcov/
 *.so
 .env
+site/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint fmt check clean examples release
+.PHONY: help install test lint fmt check clean examples docs release
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -23,6 +23,9 @@ check: lint test ## Run all checks (lint + test)
 
 examples: ## Regenerate command examples doc
 	python scripts/generate_examples.py > docs/examples.md
+
+docs: ## Serve docs locally
+	mkdocs serve
 
 clean: ## Remove build artifacts
 	rm -rf dist/ build/ *.egg-info .coverage coverage.xml htmlcov/ .mypy_cache/ .ruff_cache/ .pytest_cache/

--- a/docs/ai/errors.md
+++ b/docs/ai/errors.md
@@ -1,0 +1,53 @@
+# Error Handling
+
+## TTY-Aware Errors
+
+Errors adapt to context automatically:
+
+**Terminal (Rich mode):**
+```
+Error: Project 'Worx' not found
+  Suggestion: Run `td projects` to list available projects. Did you mean 'Work'?
+```
+
+**Piped / JSON mode:**
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "PROJECT_NOT_FOUND",
+    "message": "Project 'Worx' not found",
+    "suggestion": "Run 'td projects' to list available projects. Did you mean 'Work'?",
+    "details": {}
+  }
+}
+```
+
+Errors always go to **stderr**, keeping stdout clean for data.
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `AUTH_MISSING` | No API token configured |
+| `AUTH_INVALID` | API token is invalid |
+| `TASK_NOT_FOUND` | Task ID does not exist |
+| `PROJECT_NOT_FOUND` | Project name/ID does not exist |
+| `SECTION_NOT_FOUND` | Section name/ID does not exist |
+| `LABEL_NOT_FOUND` | Label name/ID does not exist |
+| `VALIDATION_ERROR` | Invalid input parameters |
+| `API_ERROR` | Todoist API returned an error |
+| `API_RATE_LIMIT` | Rate limit exceeded |
+| `DUPLICATE_TASK` | Task already exists (with `--idempotent`) |
+
+## Handling Errors in Code
+
+```python
+import subprocess, json
+
+result = subprocess.run(["td", "--json", "done", "bad-id"], capture_output=True, text=True)
+if result.returncode != 0:
+    error = json.loads(result.stderr)
+    code = error["error"]["code"]
+    suggestion = error["error"]["suggestion"]
+```

--- a/docs/ai/idempotency.md
+++ b/docs/ai/idempotency.md
@@ -1,0 +1,45 @@
+# Idempotent Operations
+
+## The Problem
+
+AI agents retry failed operations. Without idempotency, a retry creates a duplicate task. This is the #1 failure mode for agent-managed task lists.
+
+## The Solution
+
+```bash
+td add "Deploy v2.1" -p Releases --idempotent
+```
+
+If a task with identical content already exists in the target project, td returns the existing task instead of creating a duplicate.
+
+## Response
+
+The JSON response includes a `created` field:
+
+**New task created:**
+```json
+{
+  "ok": true,
+  "type": "task_created",
+  "data": {
+    "id": "8bx9a0c2",
+    "content": "Deploy v2.1",
+    "created": true
+  }
+}
+```
+
+**Existing task returned:**
+```json
+{
+  "ok": true,
+  "type": "task_created",
+  "data": {
+    "id": "8bx9a0c2",
+    "content": "Deploy v2.1",
+    "created": false
+  }
+}
+```
+
+Agents check `data.created` to know whether a new task was made.

--- a/docs/ai/index.md
+++ b/docs/ai/index.md
@@ -1,0 +1,31 @@
+# AI & Agent Integration
+
+td is built for AI agents as a first-class use case — and a lightweight alternative to MCP for Todoist integration.
+
+## Why td for Agents?
+
+MCP servers for Todoist exist, but they suffer from auth flakiness, excessive token consumption, and opaque error handling. td gives agents the same capabilities through a simpler interface:
+
+- **Structured JSON over stdout/stderr** — no protocol overhead
+- **Self-describing schema** — one call to `td schema` and the agent knows everything
+- **Idempotent operations** — prevents the #1 agent failure mode (duplicate creation)
+- **No persistent connection** — stateless CLI calls, no server to maintain
+
+## Quick Start for Agents
+
+```bash
+# Set token (no interactive setup needed)
+export TD_API_TOKEN="your-token"
+
+# Discover all capabilities
+td schema | jq '.commands | keys'
+
+# All output is JSON when piped
+td ls | jq '.data[].content'
+```
+
+## Topics
+
+- [Structured Output](output.md) — automatic JSON, three output modes
+- [Error Handling](errors.md) — TTY-aware errors with codes and suggestions
+- [Idempotency](idempotency.md) — preventing duplicate task creation

--- a/docs/ai/output.md
+++ b/docs/ai/output.md
@@ -1,0 +1,42 @@
+# Structured Output
+
+## Automatic JSON
+
+When stdout is not a TTY (piped or called by an agent), td outputs structured JSON automatically:
+
+```bash
+# Human in terminal sees a pretty table
+td ls
+
+# Agent piping output gets JSON
+td ls | jq '.data[].content'
+```
+
+## Three Output Modes
+
+Force a specific format with flags:
+
+```bash
+td ls --json     # JSON even in TTY
+td ls --plain    # Tab-separated, no color — for cut/awk
+```
+
+Or set a default:
+
+```bash
+export TD_FORMAT="json"
+```
+
+## Response Format
+
+All JSON responses follow the same envelope:
+
+```json
+{
+  "ok": true,
+  "type": "task_list",
+  "data": [...]
+}
+```
+
+The `type` field identifies the response kind: `task_list`, `task`, `success`, `project_list`, etc.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,0 +1,60 @@
+# Commands Reference
+
+td has 29 commands organized by function.
+
+## Task Management
+
+| Command | Description |
+|---------|-------------|
+| [`td add`](tasks.md#td-add) | Create a task with project, priority, due date, labels, section |
+| [`td quick`](tasks.md#td-quick) | Natural language task creation |
+| [`td capture`](tasks.md#td-capture) | Quick-capture to inbox |
+| [`td done`](tasks.md#td-done) | Complete a task |
+| [`td undo`](tasks.md#td-undo) | Reopen a completed task |
+| [`td edit`](tasks.md#td-edit) | Update task fields |
+| [`td move`](tasks.md#td-move) | Move a task to a different project |
+| [`td delete`](tasks.md#td-delete) | Delete a task |
+| [`td show`](tasks.md#td-show) | View full task details |
+| [`td search`](tasks.md#td-search) | Full-text search across all tasks |
+| [`td comment`](tasks.md#td-comment) | Add a comment to a task |
+| [`td comments`](tasks.md#td-comments) | List comments on a task |
+
+## Workflow
+
+| Command | Description |
+|---------|-------------|
+| [`td ls`](workflow.md#td-ls) | List tasks (defaults to today + overdue) |
+| [`td today`](workflow.md#td-today) | Morning dashboard |
+| [`td next`](workflow.md#td-next) | Highest priority task |
+| [`td inbox`](workflow.md#td-inbox) | Unprocessed inbox tasks |
+| [`td focus`](workflow.md#td-focus) | Single-project deep work view |
+| [`td log`](workflow.md#td-log) | Completed tasks |
+| [`td review`](workflow.md#td-review) | Interactive inbox processing TUI |
+
+## Organization
+
+| Command | Description |
+|---------|-------------|
+| [`td projects`](organization.md#td-projects) | List projects |
+| [`td project-add`](organization.md#td-project-add) | Create a project |
+| [`td sections`](organization.md#td-sections) | List sections |
+| [`td section-add`](organization.md#td-section-add) | Create a section |
+| [`td labels`](organization.md#td-labels) | List labels |
+| [`td label-add`](organization.md#td-label-add) | Create a label |
+
+## Utilities
+
+| Command | Description |
+|---------|-------------|
+| [`td schema`](utilities.md#td-schema) | Capability manifest (JSON) |
+| [`td rate-limit`](utilities.md#td-rate-limit) | API rate limit status |
+| [`td init`](utilities.md#td-init) | Authentication setup |
+| [`td completions`](utilities.md#td-completions) | Shell completion scripts |
+
+## Task References
+
+All task commands accept flexible references:
+
+- **Row number** — `td done 1` (from the last `td ls` output)
+- **Content match** — `td done buy milk` (fuzzy match)
+- **Task ID** — `td done 8bx9a0c2` (exact ID)

--- a/docs/commands/organization.md
+++ b/docs/commands/organization.md
@@ -1,0 +1,53 @@
+# Organization Commands
+
+## td projects
+
+List all projects.
+
+```bash
+td projects
+td projects -s Work    # search by name
+```
+
+## td project-add
+
+Create a new project.
+
+```bash
+td project-add "Side Projects"
+td project-add "Sub Project" --parent Work
+td project-add "Favorites" --favorite
+```
+
+## td sections
+
+List sections in a project.
+
+```bash
+td sections -p Work
+```
+
+## td section-add
+
+Create a new section in a project.
+
+```bash
+td section-add "In Progress" -p Work
+```
+
+## td labels
+
+List all labels.
+
+```bash
+td labels
+td labels -s urgent    # search by name
+```
+
+## td label-add
+
+Create a new label.
+
+```bash
+td label-add important
+```

--- a/docs/commands/tasks.md
+++ b/docs/commands/tasks.md
@@ -1,0 +1,121 @@
+# Task Commands
+
+## td add
+
+Create a new task with optional project, priority, due date, labels, and section.
+
+```bash
+td add "Review PR for auth module" -p Work --priority 1 -d tomorrow -l code-review
+td add "Design review" -p Work -s "In Progress"
+echo "Task from stdin" | td add
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-p`, `--project` | Project name or ID (tab-completable) |
+| `--priority` | 1=urgent, 2=high, 3=medium, 4=low |
+| `-d`, `--due` | Due date (natural language: "tomorrow", "next friday") |
+| `-l`, `--label` | Label name, repeatable (tab-completable) |
+| `-s`, `--section` | Section name, requires `--project` (tab-completable) |
+| `--desc` | Task description |
+| `--idempotent` | Skip if identical task already exists |
+
+## td quick
+
+Natural language task creation powered by Todoist's parsing engine.
+
+```bash
+td quick "Buy milk tomorrow p2 #Errands"
+echo "Deploy hotfix" | td quick
+```
+
+## td capture
+
+Quick-capture to inbox with zero friction. No parsing, no flags.
+
+```bash
+td capture call dentist about appointment
+```
+
+## td done
+
+Complete a task. Confirms on fuzzy match in TTY mode.
+
+```bash
+td done 1              # row number
+td done buy milk       # fuzzy match (confirms)
+td done 8bx9a0c2      # exact ID
+td done buy milk -y    # skip confirmation
+```
+
+## td undo
+
+Reopen a completed task.
+
+```bash
+td undo 8bx9a0c2
+```
+
+## td edit
+
+Update task fields. With no flags, shows current values.
+
+```bash
+td edit 1 --due friday --priority 2
+td edit buy milk --content "Buy whole milk"
+td edit 1                  # show current values
+```
+
+## td move
+
+Move a task to a different project.
+
+```bash
+td move 1 -p Personal
+td move buy milk -p Work
+```
+
+## td delete
+
+Delete a task. Requires confirmation unless `--yes` is passed.
+
+```bash
+td delete 1 -y
+td delete buy milk --yes
+```
+
+## td show
+
+View full task details including description, project, and all metadata.
+
+```bash
+td show 1
+td show buy milk
+```
+
+## td search
+
+Full-text search across all tasks. Results sorted by relevance.
+
+```bash
+td search deploy
+td search "blog post" -p Work
+```
+
+## td comment
+
+Add a comment to a task.
+
+```bash
+td comment 1 "Picked up 2%, not whole"
+```
+
+## td comments
+
+List all comments on a task.
+
+```bash
+td comments 1
+```

--- a/docs/commands/utilities.md
+++ b/docs/commands/utilities.md
@@ -1,0 +1,40 @@
+# Utility Commands
+
+## td schema
+
+Output a full capability manifest as JSON. Agents call this once to learn every command, argument, option, and type.
+
+```bash
+td schema
+td schema | jq '.commands | keys'
+```
+
+## td rate-limit
+
+Show current API rate limit status from cached response headers. No API call required.
+
+```bash
+td rate-limit
+```
+
+Todoist allows 450 requests per 15 minutes. td monitors usage automatically and warns to stderr when approaching the limit.
+
+## td init
+
+Interactive authentication setup. Guides you through setting up your API token via config file or environment variable.
+
+```bash
+td init
+```
+
+## td completions
+
+Generate shell completion scripts.
+
+```bash
+td completions bash
+td completions zsh
+td completions fish
+```
+
+See [Installation](../getting-started/install.md) for setup instructions.

--- a/docs/commands/workflow.md
+++ b/docs/commands/workflow.md
@@ -1,0 +1,95 @@
+# Workflow Commands
+
+## td ls
+
+List tasks. Defaults to today + overdue unless filtered.
+
+```bash
+td ls                        # today + overdue
+td ls --all                  # everything
+td ls -p Work --sort due     # project filter, sorted
+td ls -f "today & #Work"    # Todoist filter syntax
+td ls --ids                  # output only task IDs (for piping)
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-p`, `--project` | Filter by project (tab-completable) |
+| `-l`, `--label` | Filter by label (tab-completable) |
+| `-f`, `--filter` | Todoist filter query |
+| `--all` | Show all tasks (override default filter) |
+| `--sort` | Sort by: priority, due, project, created |
+| `--reverse` | Reverse sort order |
+| `--ids` | Output only task IDs, one per line |
+
+## td today
+
+Morning dashboard — overdue + due today, sorted by priority.
+
+```bash
+td today
+td today --sort due
+```
+
+## td next
+
+Show your single highest priority task.
+
+```bash
+td next
+td next -p Work    # scope to a project
+```
+
+## td inbox
+
+Show unprocessed inbox tasks.
+
+```bash
+td inbox
+```
+
+## td focus
+
+Single-project deep work view.
+
+```bash
+td focus Work
+td focus Work --sort due --reverse
+```
+
+## td log
+
+Completed tasks — your end-of-day review.
+
+```bash
+td log           # completed today
+td log --week    # completed this week
+```
+
+## td review
+
+Interactive TUI for inbox processing. Requires `todoist-cli[interactive]`.
+
+```bash
+td review              # review inbox
+td review -p Work      # review a project
+td review -f "no date" # review tasks matching a filter
+```
+
+**Keyboard shortcuts:**
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Move cursor down |
+| `k` / `↑` | Move cursor up |
+| `p` | Set project |
+| `d` | Set due date |
+| `r` | Set priority |
+| `l` | Add label |
+| `x` | Mark as done |
+| `u` | Undo last action |
+| `h` | Toggle shortcut bar |
+| `?` | Show help |
+| `q` | Quit with summary |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,49 @@
+# Contributing
+
+## Development Setup
+
+```bash
+git clone https://github.com/craigmccaskill/todoist-cli.git
+cd todoist-cli
+pip install -e ".[dev]"
+pre-commit install
+```
+
+## Commands
+
+```bash
+make check      # lint + test (the one command you need)
+make fmt        # auto-format
+make test       # tests only
+make lint       # lint only
+make examples   # regenerate docs/examples.md
+make docs       # local docs preview
+```
+
+## Architecture
+
+```
+src/td/
+  core/       # Pure business logic — no CLI dependency
+  cli/        # Click commands and output formatting
+  tui/        # Textual-based interactive components
+  schema.py   # Click command tree → JSON capability manifest
+```
+
+The core is a library. The CLI is one frontend. The TUI is another. Both share the same business logic.
+
+## Adding a Command
+
+1. Add business logic to `src/td/core/` (if needed)
+2. Add the Click command to `src/td/cli/`
+3. Register in `src/td/cli/__init__.py`
+4. Add tests
+5. Update the schema test expected command set
+6. Run `make check`
+
+## Conventions
+
+- **Conventional commits**: `feat(scope):`, `fix:`, `docs:`, `chore:`
+- **mypy strict**: no `Any` without good reason
+- **85% coverage minimum**: enforced in CI
+- **ruff**: linting and formatting

--- a/docs/getting-started/config.md
+++ b/docs/getting-started/config.md
@@ -1,0 +1,38 @@
+# Configuration
+
+Config lives at `~/.config/td/config.toml` (respects `XDG_CONFIG_HOME`).
+
+## Config File
+
+```toml
+[auth]
+api_token = "your-todoist-api-token"
+
+[settings]
+default_command = "today"    # command to run when td is called with no args
+default_format = "rich"      # "rich", "plain", or "json"
+default_sort = "priority"    # "priority", "due", "project", "created"
+color = true                 # set false to disable colors
+```
+
+## Environment Variables
+
+Environment variables override config file values:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `TD_API_TOKEN` | API token (preferred for agents/CI) | `export TD_API_TOKEN="abc..."` |
+| `TD_FORMAT` | Default output format | `export TD_FORMAT="json"` |
+| `TD_SORT` | Default sort order | `export TD_SORT="due"` |
+| `TD_DEFAULT_CMD` | Default command | `export TD_DEFAULT_CMD="inbox"` |
+| `TD_DEBUG` | Enable debug logging | `export TD_DEBUG=1` |
+| `NO_COLOR` | Disable all colors | `export NO_COLOR=1` |
+
+## Resolution Order
+
+For each setting, the most specific source wins:
+
+1. CLI flags (`--json`, `--plain`, `--sort`)
+2. Environment variables (`TD_FORMAT`, `TD_SORT`)
+3. Config file (`~/.config/td/config.toml`)
+4. Built-in defaults

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,0 +1,38 @@
+# Installation
+
+## From Source
+
+```bash
+git clone https://github.com/craigmccaskill/todoist-cli.git
+cd todoist-cli
+pip install -e .
+```
+
+Requires Python 3.10+.
+
+## Optional Extras
+
+### Interactive TUI
+
+For the interactive task picker and `td review` inbox processing:
+
+```bash
+pip install -e ".[interactive]"
+```
+
+### Shell Completions
+
+After installing, generate completions for your shell:
+
+```bash
+# Bash
+td completions bash >> ~/.bashrc
+
+# Zsh
+td completions zsh >> ~/.zshrc
+
+# Fish
+td completions fish > ~/.config/fish/completions/td.fish
+```
+
+Restart your shell or `source` the file to enable.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,57 @@
+# Quick Start
+
+## Authentication
+
+Set up your API token:
+
+```bash
+td init
+```
+
+Or set the environment variable directly:
+
+```bash
+export TD_API_TOKEN="your-token-here"
+```
+
+Get your token from [Todoist Developer Settings](https://app.todoist.com/app/settings/integrations/developer).
+
+## Your First Commands
+
+```bash
+# See what's due today
+td today
+
+# Add a task
+td add "Review PR for auth module" -p Work --priority 1 -d tomorrow
+
+# Quick natural language add
+td quick "Buy milk tomorrow p2 #Errands"
+
+# Quick capture to inbox
+td capture call dentist about appointment
+
+# Complete a task (fuzzy match)
+td done buy milk
+
+# Search across all tasks
+td search deploy
+
+# View full task details
+td show 1
+```
+
+## Default Command
+
+Running `td` with no subcommand shows your today view:
+
+```bash
+td          # same as td today
+```
+
+Configure the default in `~/.config/td/config.toml`:
+
+```toml
+[settings]
+default_command = "today"  # or "ls", "inbox", "next"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,30 @@
+# td — AI-Native Todoist CLI
+
+A modern Todoist CLI built for both humans and AI agents. 29 commands, TTY-aware output, interactive TUI.
+
+## Why td?
+
+Existing options are broken:
+
+- **sachaos/todoist** (~1.4k stars) — semi-abandoned, uses the deprecated Sync API
+- **MCP integrations** — auth flakiness, excessive token usage for simple operations
+- **Every other CLI** — unstructured output, no introspection, agents can't self-discover capabilities
+
+td closes the gap: a maintained, fast CLI where AI discoverability is a design constraint, not an afterthought.
+
+## Key Features
+
+- **TTY-aware everything** — pretty Rich tables for humans, structured JSON when piped. No flags needed.
+- **Interactive TUI** — `td review` opens an inbox-processing interface with keyboard navigation. Commands launch task pickers when called with no args.
+- **Fuzzy task matching** — `td done buy milk` finds and completes the right task. Confirms before acting on ambiguous matches.
+- **AI-native** — capability manifest via `td schema`, structured errors with codes, idempotent operations.
+- **Rate limit awareness** — monitors API usage, warns before you hit the limit.
+
+## Quick Links
+
+- [Installation](getting-started/install.md)
+- [Quick Start](getting-started/quickstart.md)
+- [Commands Reference](commands/index.md)
+- [AI/Agent Integration](ai/index.md)
+- [GitHub Repository](https://github.com/craigmccaskill/todoist-cli)
+- [Roadmap](https://github.com/users/craigmccaskill/projects/1)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,61 @@
+site_name: td — AI-Native Todoist CLI
+site_description: A modern Todoist CLI built for both humans and AI agents
+site_url: https://craigmccaskill.github.io/todoist-cli/
+repo_url: https://github.com/craigmccaskill/todoist-cli
+repo_name: craigmccaskill/todoist-cli
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
+    - search.suggest
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/install.md
+    - Quick Start: getting-started/quickstart.md
+    - Configuration: getting-started/config.md
+  - Commands:
+    - Overview: commands/index.md
+    - Task Management: commands/tasks.md
+    - Organization: commands/organization.md
+    - Workflow: commands/workflow.md
+    - Utilities: commands/utilities.md
+  - AI & Agent Integration:
+    - Overview: ai/index.md
+    - Structured Output: ai/output.md
+    - Error Handling: ai/errors.md
+    - Idempotency: ai/idempotency.md
+  - Contributing: contributing.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,12 @@ lint = [
 interactive = [
     "textual>=0.50",
 ]
+docs = [
+    "mkdocs-material",
+    "mkdocs-click",
+]
 dev = [
-    "todoist-cli[test,lint,interactive]",
+    "todoist-cli[test,lint,interactive,docs]",
     "pre-commit",
 ]
 


### PR DESCRIPTION
## Summary
- Full documentation site built with mkdocs-material
- Sections: Getting Started, Commands Reference (29 commands), AI/Agent Integration, Contributing
- Dark/light theme toggle
- Auto-deploys to GitHub Pages on push to main (docs/** or mkdocs.yml)
- `make docs` for local preview
- mkdocs-material and mkdocs-click added as optional `[docs]` dependency

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)