### PR TITLE
chore(release): v0.7.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0-alpha] - 2026-03-25
+
+### Added
+- Dynamic shell completions for project, label, and section names (#24)
+- Documentation site with mkdocs-material — deployed to GitHub Pages (#38)
+- `make docs` for local documentation preview
+
 ## [0.6.0-alpha] - 2026-03-25
 
 ### Added

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -59,7 +59,7 @@ Commands:
 
 ```
 $ td --version
-td, version 0.6.0-alpha
+td, version 0.7.0-alpha
 ```
 
 
@@ -884,7 +884,7 @@ Output the full capability manifest. Agents call this once to learn everything.
 $ td schema
 {
   "name": "td",
-  "version": "0.6.0-alpha",
+  "version": "0.7.0-alpha",
   "description": "AI-native Todoist CLI",
   "commands": {
     "add": {

--- a/src/td/__init__.py
+++ b/src/td/__init__.py
@@ -1,3 +1,3 @@
 """td — AI-native Todoist CLI."""
 
-__version__ = "0.6.0-alpha"
+__version__ = "0.7.0-alpha"


### PR DESCRIPTION
## Summary
- Version bump to 0.7.0-alpha
- CHANGELOG.md with shell completions and docs site
- Regenerated docs/examples.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)