### PR TITLE
ci: add pytest-timeout and CI job timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -24,6 +25,7 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+- Add pytest-timeout (30s per test) and CI job timeouts to prevent hanging tests (#140)
+
 ## [0.8.0-alpha] - 2026-04-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ test = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-mock",
+    "pytest-timeout>=2.3",
 ]
 lint = [
     "ruff",
@@ -99,6 +100,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=td --cov-report=term-missing"
+timeout = 30
 
 [tool.coverage.run]
 source = ["td"]


### PR DESCRIPTION
## Related issues

Closes #140

## What

Add pytest-timeout plugin (30s per test) and explicit `timeout-minutes` on CI jobs (lint: 10min, test: 20min).

## Why

No timeout protection existed — a hanging test (e.g., TUI async pilot test with a blocked event loop) would block CI for up to 6 hours (GitHub Actions default). This adds two layers of defense: per-test timeout for fast feedback, and job-level timeout as a safety net.

## How to test

- CI should pass with the new timeout settings
- All existing tests complete well within 30s (they're mocked, typically <1s each)

## Checklist

- [x] `make check` passes (lint + tests)
- [x] CHANGELOG.md updated under `[Unreleased]` (Internal)
- [ ] Bug fixes include a regression test — N/A (infrastructure config)
- [ ] Help text updated for new/changed commands — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)