### PR TITLE
ci: add packaging verification to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,32 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: pip-audit --desc
 
+  packaging:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: 'pip'
+      - run: pip install build
+      - run: python -m build
+      - name: Verify sdist install
+        run: |
+          python -m venv /tmp/test-sdist
+          /tmp/test-sdist/bin/pip install dist/*.tar.gz
+          /tmp/test-sdist/bin/td --version
+          /tmp/test-sdist/bin/td schema > /dev/null
+          /tmp/test-sdist/bin/python -c "import td; assert ((__import__('pathlib').Path(td.__file__).parent) / 'py.typed').exists()"
+      - name: Verify wheel install
+        run: |
+          python -m venv /tmp/test-wheel
+          /tmp/test-wheel/bin/pip install dist/*.whl
+          /tmp/test-wheel/bin/td --version
+          /tmp/test-wheel/bin/td schema > /dev/null
+          /tmp/test-wheel/bin/python -c "import td; assert ((__import__('pathlib').Path(td.__file__).parent) / 'py.typed').exists()"
+
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Empty list states show helpful messages instead of empty tables
   - `search` and `log` commands now include project name column
 - Full UX review: improved help text, documented defaults, consistent flag descriptions, cleaner error messages (#122)
+- Add CI packaging verification — build sdist/wheel and smoke-test installs on every push/PR (#150)
 
 ### Fixed
 - TUI `RowKey` resolution: use `row_key.value` instead of `str(row_key)` for Textual 8.x compatibility in picker and review modal screens (#159)


### PR DESCRIPTION
## Related issues

Closes #150

## What

New `packaging` CI job that builds sdist and wheel, installs each in a fresh venv, and runs smoke tests:
- `td --version` — entry point works
- `td schema` — all subpackages import correctly (walks entire Click command tree)
- `py.typed` presence check — PEP 561 marker ships correctly

## Why

CI only tested editable installs (`pip install -e .`), which symlink to the source tree. Real user installs copy files into site-packages — missing files or broken entry points are invisible in editable mode. The `py.typed` bug (PR #162) is a concrete example: it passed all CI checks but was missing from published wheels.

## How to test

- CI packaging job should pass — builds artifacts, installs them, smoke tests succeed
- Verify the job runs on this PR itself

## Checklist

- [x] `make check` passes (lint + tests)
- [x] CHANGELOG.md updated under `[Unreleased]` (Internal)
- [ ] Bug fixes include a regression test — N/A
- [ ] Help text updated for new/changed commands — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)