### PR TITLE
fix(config): prevent API token exposure in shell history during td init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add pytest-timeout (30s per test) and CI job timeouts to prevent hanging tests (#140)
 - Add dependency vulnerability scanning with pip-audit in CI and `make audit` locally (#146)
 - Enhance PR template with CONTRIBUTING.md workflow checklist and consolidate feature templates (#148)
+### Fixed
+- `td init` no longer exposes API token in shell history when choosing environment variable storage (#138)
 
 ## [0.8.0-alpha] - 2026-04-04
 

--- a/src/td/cli/config_cmd.py
+++ b/src/td/cli/config_cmd.py
@@ -59,15 +59,14 @@ def init() -> None:
     else:
         shell = os.environ.get("SHELL", "/bin/bash")
         click.echo()
-        if "fish" in shell:
-            click.echo("Add to ~/.config/fish/config.fish:")
-            click.echo(f'  set -x TD_API_TOKEN "{token}"')
-        else:
-            click.echo("Add to your shell profile (~/.bashrc, ~/.zshrc):")
-            click.echo(f'  export TD_API_TOKEN="{token}"')
+        click.echo("Run this command to set your token (it won't appear in shell history):")
         click.echo()
-        click.echo("Or for a .env file:")
-        click.echo(f"  TD_API_TOKEN={token}")
+        if "fish" in shell:
+            click.echo("  read -s -P 'Token: ' TD_API_TOKEN && set -x TD_API_TOKEN $TD_API_TOKEN")
+        else:
+            click.echo("  read -rs TD_API_TOKEN && export TD_API_TOKEN")
+        click.echo()
+        click.echo("To persist it, add TD_API_TOKEN to your shell profile or .env file.")
 
     click.echo()
     click.echo("Try `td ls` to see your tasks.")

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -70,6 +70,28 @@ class TestInit:
         assert result.exit_code == 0
         assert "Aborted" in result.output
 
+    def test_init_env_var_does_not_expose_token(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("TD_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("TD_API_TOKEN", raising=False)
+
+        mock_api = MagicMock()
+        mock_api.get_projects.return_value = iter(
+            [
+                [MagicMock(), MagicMock()],
+            ]
+        )
+
+        monkeypatch.setattr("td.cli.config_cmd.TodoistAPI", lambda token: mock_api)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["init"], input="secret-token-abc123\n2\n")
+
+        assert result.exit_code == 0
+        assert "secret-token-abc123" not in result.output
+        assert "TD_API_TOKEN" in result.output
+
 
 class TestCompletions:
     @pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])


### PR DESCRIPTION
## Related issues

Closes #138

## What

Replace raw token output in `td init` env var path with safe shell commands that don't capture the token in shell history:
- bash/zsh: `read -rs TD_API_TOKEN && export TD_API_TOKEN`
- fish: `read -s -P 'Token: ' TD_API_TOKEN && set -x TD_API_TOKEN $TD_API_TOKEN`

## Why

When users chose option 2 (environment variable) during `td init`, the CLI printed `export TD_API_TOKEN="actual-token"`. Copying and pasting this into a shell saves the token in `~/.bash_history` / `~/.zsh_history`. The `read -rs` approach prompts for the token interactively without history capture.

## How to test

- Run `td init`, choose option 2 — verify no token appears in output
- New regression test: `test_init_env_var_does_not_expose_token`

## Checklist

- [x] `make check` passes (lint + tests) — 209 passed
- [x] CHANGELOG.md updated under `[Unreleased]` (Fixed)
- [x] Bug fixes include a regression test
- [ ] Help text updated for new/changed commands — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)