### PR TITLE
fix(tui): implement filter, undo, and fix keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhance PR template with CONTRIBUTING.md workflow checklist and consolidate feature templates (#148)
 ### Fixed
 - `td init` no longer exposes API token in shell history when choosing environment variable storage (#138)
+### Changed
+- Fix TUI keyboard shortcuts: implement `/` filter in picker, real undo in review, modal Enter binding, standardize hints (#117)
 
 ## [0.8.0-alpha] - 2026-04-04
 

--- a/src/td/tui/picker.py
+++ b/src/td/tui/picker.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar
 from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
-from textual.widgets import DataTable, Static
+from textual.widgets import DataTable, Input, Static
 
 
 class PickerApp(App[str | None]):
@@ -26,6 +26,13 @@ class PickerApp(App[str | None]):
         text-align: center;
         padding: 1 0;
         color: $text-muted;
+    }
+    #filter-input {
+        display: none;
+        padding: 0 1;
+    }
+    #filter-input.visible {
+        display: block;
     }
     DataTable {
         height: auto;
@@ -51,10 +58,12 @@ class PickerApp(App[str | None]):
         self._columns = columns
         self._rows = rows
         self._key_field = key_field
-        self._all_rows = rows
+        self._all_rows = list(rows)
+        self._filter_active = False
 
     def compose(self) -> ComposeResult:
         yield Static(self._title, id="title")
+        yield Input(placeholder="Filter...", id="filter-input", disabled=True)
         table: DataTable[str] = DataTable(cursor_type="row")
         for col in self._columns:
             table.add_column(col, key=col)
@@ -65,9 +74,70 @@ class PickerApp(App[str | None]):
             )
         yield table
         yield Static(
-            "↑/↓ navigate · enter select · esc cancel",
+            "\u2191/\u2193 navigate \u00b7 / filter \u00b7 enter select \u00b7 esc cancel",
             id="hint",
         )
+
+    def on_mount(self) -> None:
+        """Ensure the DataTable has focus on startup."""
+        self.query_one(DataTable).focus()
+
+    def action_filter(self) -> None:
+        """Show the filter input and focus it."""
+        if self._filter_active:
+            return
+        self._filter_active = True
+        filter_input = self.query_one("#filter-input", Input)
+        filter_input.disabled = False
+        filter_input.add_class("visible")
+        filter_input.value = ""
+        filter_input.focus()
+
+    def _close_filter(self) -> None:
+        """Hide the filter input, restore all rows, and refocus the table."""
+        self._filter_active = False
+        filter_input = self.query_one("#filter-input", Input)
+        filter_input.remove_class("visible")
+        filter_input.value = ""
+        filter_input.disabled = True
+        self._repopulate_table(self._all_rows)
+        self.query_one(DataTable).focus()
+
+    def _repopulate_table(self, rows: list[dict[str, Any]]) -> None:
+        """Clear and repopulate the table with the given rows."""
+        table = self.query_one(DataTable)
+        table.clear()
+        for row in rows:
+            table.add_row(
+                *[str(row.get(col, "")) for col in self._columns],
+                key=str(row[self._key_field]),
+            )
+
+    @on(Input.Changed, "#filter-input")
+    def on_filter_changed(self, event: Input.Changed) -> None:
+        """Live-filter table rows as the user types."""
+        query = event.value.strip().lower()
+        if not query:
+            self._repopulate_table(self._all_rows)
+            return
+        filtered = [
+            row
+            for row in self._all_rows
+            if any(query in str(row.get(col, "")).lower() for col in self._columns)
+        ]
+        self._repopulate_table(filtered)
+
+    @on(Input.Submitted, "#filter-input")
+    def on_filter_submitted(self, _event: Input.Submitted) -> None:
+        """When Enter is pressed in the filter, refocus the table."""
+        self.query_one(DataTable).focus()
+
+    def on_key(self, event: Any) -> None:
+        """Handle Escape in filter input to close the filter."""
+        if self._filter_active and event.key == "escape":
+            event.prevent_default()
+            event.stop()
+            self._close_filter()
 
     def action_select(self) -> None:
         table = self.query_one(DataTable)

--- a/src/td/tui/review.py
+++ b/src/td/tui/review.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from textual import on
 from textual.app import App, ComposeResult
@@ -20,13 +20,27 @@ _PRIORITY_STYLES = {4: "red bold", 3: "yellow", 2: "blue", 1: "dim"}
 
 
 @dataclass
+class UndoEntry:
+    """State needed to reverse a single review action."""
+
+    action: str
+    task_id: str
+    task_content: str
+    old_project_id: str | None = None
+    old_priority: int | None = None
+    old_labels: list[str] | None = None
+    old_due_string: str | None = None
+    task: Task | None = None
+
+
+@dataclass
 class ReviewStats:
     """Track changes made during the review session."""
 
     updated: list[str] = field(default_factory=list)
     completed: list[str] = field(default_factory=list)
     skipped: int = 0
-    undo_stack: list[dict[str, Any]] = field(default_factory=list)
+    undo_stack: list[UndoEntry] = field(default_factory=list)
 
 
 class ProjectPickerScreen(ModalScreen[str | None]):
@@ -34,6 +48,7 @@ class ProjectPickerScreen(ModalScreen[str | None]):
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "cancel", "Cancel"),
+        Binding("enter", "select", "Select"),
     ]
 
     def __init__(self, projects: list[dict[str, str]]) -> None:
@@ -52,6 +67,12 @@ class ProjectPickerScreen(ModalScreen[str | None]):
     def on_row_selected(self, event: DataTable.RowSelected) -> None:
         self.dismiss(str(event.row_key.value))
 
+    def action_select(self) -> None:
+        table = self.query_one(DataTable)
+        if table.row_count > 0:
+            row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
+            self.dismiss(str(row_key))
+
     def action_cancel(self) -> None:
         self.dismiss(None)
 
@@ -61,21 +82,28 @@ class PriorityPickerScreen(ModalScreen[int | None]):
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "cancel", "Cancel"),
+        Binding("enter", "select", "Select"),
     ]
 
     def compose(self) -> ComposeResult:
         yield Static("Set priority:", id="picker-title")
         table: DataTable[str] = DataTable(cursor_type="row", id="picker-table")
         table.add_column("Priority", key="priority")
-        table.add_row("p1 — Urgent", key="4")
-        table.add_row("p2 — High", key="3")
-        table.add_row("p3 — Medium", key="2")
-        table.add_row("p4 — Low", key="1")
+        table.add_row("p1 \u2014 Urgent", key="4")
+        table.add_row("p2 \u2014 High", key="3")
+        table.add_row("p3 \u2014 Medium", key="2")
+        table.add_row("p4 \u2014 Low", key="1")
         yield table
 
     @on(DataTable.RowSelected)
     def on_row_selected(self, event: DataTable.RowSelected) -> None:
         self.dismiss(int(str(event.row_key.value)))
+
+    def action_select(self) -> None:
+        table = self.query_one(DataTable)
+        if table.row_count > 0:
+            row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
+            self.dismiss(int(str(row_key)))
 
     def action_cancel(self) -> None:
         self.dismiss(None)
@@ -86,6 +114,7 @@ class LabelPickerScreen(ModalScreen[str | None]):
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "cancel", "Cancel"),
+        Binding("enter", "select", "Select"),
     ]
 
     def __init__(self, labels: list[str]) -> None:
@@ -103,6 +132,12 @@ class LabelPickerScreen(ModalScreen[str | None]):
     @on(DataTable.RowSelected)
     def on_row_selected(self, event: DataTable.RowSelected) -> None:
         self.dismiss(str(event.row_key.value))
+
+    def action_select(self) -> None:
+        table = self.query_one(DataTable)
+        if table.row_count > 0:
+            row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
+            self.dismiss(str(row_key))
 
     def action_cancel(self) -> None:
         self.dismiss(None)
@@ -168,8 +203,8 @@ class ReviewApp(App[ReviewStats]):
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
-        Binding("j", "cursor_down", "Down", show=False),
-        Binding("k", "cursor_up", "Up", show=False),
+        Binding("j", "cursor_down", "j/\u2193 Down"),
+        Binding("k", "cursor_up", "k/\u2191 Up"),
         Binding("p", "set_project", "Project"),
         Binding("d", "set_due", "Due date"),
         Binding("r", "set_priority", "Priority"),
@@ -215,8 +250,9 @@ class ReviewApp(App[ReviewStats]):
         yield Static("", id="status-line")
         yield Vertical(
             Static(
-                "p project · d due · r priority · l label · x done\n"
-                "u undo · h hide shortcuts · ? help · q quit",
+                "j/\u2193 down \u00b7 k/\u2191 up \u00b7 p project \u00b7 d due \u00b7"
+                " r priority \u00b7 l label \u00b7 x done\n"
+                "u undo \u00b7 h hide shortcuts \u00b7 ? help \u00b7 q quit",
                 id="shortcuts",
             ),
         )
@@ -231,9 +267,9 @@ class ReviewApp(App[ReviewStats]):
         for i, task in enumerate(self._tasks, 1):
             status = ""
             if task.content in self._stats.completed:
-                status = "✗"
+                status = "\u2717"
             elif task.content in self._stats.updated:
-                status = "✓"
+                status = "\u2713"
             pri = _PRIORITY_LABELS.get(task.priority, "p4")
             project = self._project_map.get(task.project_id, "")
             due = task.due.string if task.due else ""
@@ -245,10 +281,12 @@ class ReviewApp(App[ReviewStats]):
         updated = len(self._stats.updated)
         completed = len(self._stats.completed)
         status = self.query_one("#status-line", Static)
-        status.update(f"✓ {updated} updated · ✗ {completed} done · {remaining} remaining")
+        status.update(
+            f"\u2713 {updated} updated \u00b7 \u2717 {completed} done \u00b7 {remaining} remaining"
+        )
 
     def _set_feedback(self, msg: str) -> None:
-        self.query_one("#feedback", Static).update(f"✓ {msg}")
+        self.query_one("#feedback", Static).update(f"\u2713 {msg}")
 
     def _get_selected_task(self) -> Task | None:
         table = self.query_one("#review-table", DataTable)
@@ -268,6 +306,8 @@ class ReviewApp(App[ReviewStats]):
         if not task:
             return
 
+        old_project_id = task.project_id
+
         def on_project(project_id: str | None) -> None:
             if project_id and task:
                 self._api.move_task(task.id, project_id=project_id)
@@ -276,9 +316,14 @@ class ReviewApp(App[ReviewStats]):
                 if task.content not in self._stats.updated:
                     self._stats.updated.append(task.content)
                 self._stats.undo_stack.append(
-                    {"action": "project", "task_id": task.id, "old_project": task.project_id}
+                    UndoEntry(
+                        action="project",
+                        task_id=task.id,
+                        task_content=task.content,
+                        old_project_id=old_project_id,
+                    )
                 )
-                self._set_feedback(f"{task.content} → {project_name}")
+                self._set_feedback(f"{task.content} \u2192 {project_name}")
                 self._refresh_table()
                 self._update_status()
 
@@ -289,12 +334,22 @@ class ReviewApp(App[ReviewStats]):
         if not task:
             return
 
+        old_due_string = task.due.string if task.due else None
+
         def on_due(due_string: str | None) -> None:
             if due_string and task:
                 self._api.update_task(task.id, due_string=due_string)
                 if task.content not in self._stats.updated:
                     self._stats.updated.append(task.content)
-                self._set_feedback(f"{task.content} → due {due_string}")
+                self._stats.undo_stack.append(
+                    UndoEntry(
+                        action="due",
+                        task_id=task.id,
+                        task_content=task.content,
+                        old_due_string=old_due_string,
+                    )
+                )
+                self._set_feedback(f"{task.content} \u2192 due {due_string}")
                 self._refresh_table()
                 self._update_status()
 
@@ -305,6 +360,8 @@ class ReviewApp(App[ReviewStats]):
         if not task:
             return
 
+        old_priority = task.priority
+
         def on_priority(priority: int | None) -> None:
             if priority is not None and task:
                 self._api.update_task(task.id, priority=priority)
@@ -312,7 +369,15 @@ class ReviewApp(App[ReviewStats]):
                 if task.content not in self._stats.updated:
                     self._stats.updated.append(task.content)
                 pri_label = _PRIORITY_LABELS.get(priority, "p4")
-                self._set_feedback(f"{task.content} → {pri_label}")
+                self._stats.undo_stack.append(
+                    UndoEntry(
+                        action="priority",
+                        task_id=task.id,
+                        task_content=task.content,
+                        old_priority=old_priority,
+                    )
+                )
+                self._set_feedback(f"{task.content} \u2192 {pri_label}")
                 self._refresh_table()
                 self._update_status()
 
@@ -323,6 +388,8 @@ class ReviewApp(App[ReviewStats]):
         if not task:
             return
 
+        old_labels = list(task.labels) if task.labels else []
+
         def on_label(label_name: str | None) -> None:
             if label_name and task:
                 new_labels = [*(task.labels or []), label_name]
@@ -330,7 +397,15 @@ class ReviewApp(App[ReviewStats]):
                 task.labels = new_labels
                 if task.content not in self._stats.updated:
                     self._stats.updated.append(task.content)
-                self._set_feedback(f"{task.content} → @{label_name}")
+                self._stats.undo_stack.append(
+                    UndoEntry(
+                        action="label",
+                        task_id=task.id,
+                        task_content=task.content,
+                        old_labels=old_labels,
+                    )
+                )
+                self._set_feedback(f"{task.content} \u2192 @{label_name}")
                 self._refresh_table()
                 self._update_status()
 
@@ -343,6 +418,14 @@ class ReviewApp(App[ReviewStats]):
 
         self._api.complete_task(task.id)
         self._stats.completed.append(task.content)
+        self._stats.undo_stack.append(
+            UndoEntry(
+                action="done",
+                task_id=task.id,
+                task_content=task.content,
+                task=task,
+            )
+        )
         self._tasks.remove(task)
         del self._task_map[task.id]
         self._set_feedback(f"Completed: {task.content}")
@@ -356,24 +439,52 @@ class ReviewApp(App[ReviewStats]):
         if not self._stats.undo_stack:
             self._set_feedback("Nothing to undo")
             return
-        # Simple undo — just notify, full undo would need API revert
-        self._stats.undo_stack.pop()
-        self._set_feedback("Undo not yet implemented for API changes")
+
+        entry = self._stats.undo_stack.pop()
+        try:
+            if entry.action == "project" and entry.old_project_id:
+                self._api.move_task(entry.task_id, project_id=entry.old_project_id)
+                if entry.task_id in self._task_map:
+                    self._task_map[entry.task_id].project_id = entry.old_project_id
+            elif entry.action == "priority" and entry.old_priority is not None:
+                self._api.update_task(entry.task_id, priority=entry.old_priority)
+                if entry.task_id in self._task_map:
+                    self._task_map[entry.task_id].priority = entry.old_priority
+            elif entry.action == "label" and entry.old_labels is not None:
+                self._api.update_task(entry.task_id, labels=entry.old_labels)
+                if entry.task_id in self._task_map:
+                    self._task_map[entry.task_id].labels = entry.old_labels
+            elif entry.action == "due":
+                due_str = entry.old_due_string if entry.old_due_string else "no date"
+                self._api.update_task(entry.task_id, due_string=due_str)
+            elif entry.action == "done" and entry.task:
+                self._api.uncomplete_task(entry.task_id)
+                self._tasks.append(entry.task)
+                self._task_map[entry.task_id] = entry.task
+                if entry.task_content in self._stats.completed:
+                    self._stats.completed.remove(entry.task_content)
+
+            self._set_feedback(f"Undone: {entry.task_content}")
+            self._refresh_table()
+            self._update_status()
+        except Exception as e:
+            self._set_feedback(f"Undo failed: {e}")
 
     def action_toggle_shortcuts(self) -> None:
         self._show_shortcuts = not self._show_shortcuts
         shortcuts = self.query_one("#shortcuts", Static)
         if self._show_shortcuts:
             shortcuts.update(
-                "p project · d due · r priority · l label · x done\n"
-                "u undo · h hide shortcuts · ? help · q quit"
+                "j/\u2193 down \u00b7 k/\u2191 up \u00b7 p project \u00b7 d due \u00b7"
+                " r priority \u00b7 l label \u00b7 x done\n"
+                "u undo \u00b7 h hide shortcuts \u00b7 ? help \u00b7 q quit"
             )
         else:
-            shortcuts.update("h show shortcuts · ? help")
+            shortcuts.update("h show shortcuts \u00b7 ? help")
 
     def action_show_help(self) -> None:
         help_text = (
-            "j/↓  Move down    k/↑  Move up\n"
+            "j/\u2193  Move down    k/\u2191  Move up\n"
             "p    Set project   d    Set due date\n"
             "r    Set priority  l    Add label\n"
             "x    Mark done     u    Undo last\n"


### PR DESCRIPTION
## Related issues

Closes #117

## What

- **Live filter in PickerApp**: Press `/` to open filter input, type to narrow rows in real-time, Escape to close and restore all rows
- **Real undo in ReviewApp**: Typed `UndoEntry` stack stores enough state to reverse all action types — project moves, priority/label/due changes, and task completion (via `uncomplete_task`)
- **Enter binding on modal screens**: ProjectPicker, PriorityPicker, and LabelPicker now have explicit `action_select` for keyboard-only navigation
- **Standardized hints**: j/k navigation shown in shortcuts, all hint text matches actual bindings

## Why

Several TUI keyboard shortcuts were broken or misleading: `/` filter was bound but unimplemented, `u` undo was a stub that showed "not yet implemented", and modal screens relied solely on DataTable row selection events without an explicit Enter binding.

## How to test

- `td review` — test all shortcuts, undo an action, use `/` filter in project picker
- Existing TUI pilot tests pass (208 total)

## Checklist

- [x] `make check` passes (lint + tests) — 208 passed, 87% coverage
- [x] CHANGELOG.md updated under `[Unreleased]` (Changed)
- [ ] Bug fixes include a regression test — TUI tests added in #159
- [ ] Help text updated for new/changed commands — hints updated in TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)