### PR TITLE
feat(output): comprehensive output polish across all list views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `td init` no longer exposes API token in shell history when choosing environment variable storage (#138)
 ### Changed
 - Fix TUI keyboard shortcuts: implement `/` filter in picker, real undo in review, modal Enter binding, standardize hints (#117)
+- Audit and improve table columns across all list views (#112)
+  - Task list plain mode now matches Rich column order: #, PRI, CONTENT, PROJECT, DUE, LABELS
+  - Smart column hiding in plain mode: PROJECT and LABELS columns auto-hide when not applicable
+  - Project list: consistent NAME, ★, ID order with favorite indicator in plain mode
+  - Label list: `@` prefix in plain mode to match Rich
+  - Section list: NAME, ID order in plain mode (was ID, NAME)
+  - Comment rendering moved into `OutputFormatter.comment_list()` with human-readable timestamps
+  - Overdue due dates styled red (was yellow) in Rich task tables
+  - Empty list states show helpful messages instead of empty tables
+  - `search` and `log` commands now include project name column
 
 ## [0.8.0-alpha] - 2026-04-04
 

--- a/src/td/cli/comments.py
+++ b/src/td/cli/comments.py
@@ -54,23 +54,4 @@ def comments(ctx: click.Context, task_ref: str | None) -> None:
     task_id = _require_task(task_ref, api)
 
     all_comments = [c for page in api.get_comments(task_id=task_id) for c in page]
-
-    if fmt.mode.value == "json":
-        fmt._json_out([c.to_dict() for c in all_comments], "comment_list")
-    elif fmt.mode.value == "plain":
-        click.echo("ID\tCONTENT\tPOSTED")
-        for c in all_comments:
-            click.echo(f"{c.id}\t{c.content}\t{c.posted_at}")
-    else:
-        assert fmt._console is not None
-        from rich.table import Table
-
-        table = Table(title="Comments", show_lines=False)
-        table.add_column("Content", style="bold")
-        table.add_column("Posted", style="dim")
-        table.add_column("ID", style="dim")
-
-        for c in all_comments:
-            table.add_row(c.content, str(c.posted_at), c.id)
-
-        fmt._console.print(table)
+    fmt.comment_list(all_comments)

--- a/src/td/cli/output.py
+++ b/src/td/cli/output.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -11,7 +12,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 from rich.text import Text
-from todoist_api_python.models import Label, Project, Section, Task
+from todoist_api_python.models import Comment, Label, Project, Section, Task
 
 from td.core.cache import save_result_cache
 
@@ -65,6 +66,57 @@ _PRIORITY_STYLES = {
 }
 
 
+def _is_overdue(due_string: str) -> bool:
+    """Check if a YYYY-MM-DD date string is before today."""
+    try:
+        due_date = datetime.strptime(due_string, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        today = datetime.now(tz=timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        return due_date < today
+    except ValueError:
+        return False
+
+
+def _format_timestamp(iso_str: str) -> str:
+    """Format an ISO timestamp into a human-readable relative string.
+
+    <1h -> "Xm ago", <24h -> "Xh ago", <7d -> "Xd ago", else "Mon DD".
+    """
+    try:
+        posted = datetime.fromisoformat(str(iso_str))
+        if posted.tzinfo is None:
+            posted = posted.replace(tzinfo=timezone.utc)
+        now = datetime.now(tz=timezone.utc)
+        delta = now - posted
+        total_seconds = int(delta.total_seconds())
+
+        if total_seconds < 0:
+            return str(iso_str)
+        if total_seconds < 3600:
+            minutes = max(1, total_seconds // 60)
+            return f"{minutes}m ago"
+        if total_seconds < 86400:
+            hours = total_seconds // 3600
+            return f"{hours}h ago"
+        if total_seconds < 604800:
+            days = total_seconds // 86400
+            return f"{days}d ago"
+        return posted.strftime("%b %d")
+    except (ValueError, TypeError):
+        return str(iso_str)
+
+
+def _empty_message(item_type: str) -> str:
+    """Return a user-friendly empty state message."""
+    messages = {
+        "tasks": "No tasks found.",
+        "projects": "No projects found.",
+        "labels": "No labels found.",
+        "sections": "No sections found.",
+        "comments": "No comments found.",
+    }
+    return messages.get(item_type, f"No {item_type} found.")
+
+
 def _task_to_dict(task: Task, project_names: dict[str, str] | None = None) -> dict[str, Any]:
     """Convert a Task to a plain dict for JSON output."""
     d = task.to_dict()
@@ -73,13 +125,28 @@ def _task_to_dict(task: Task, project_names: dict[str, str] | None = None) -> di
     return d
 
 
-def _task_plain_row(task: Task, project_names: dict[str, str] | None = None) -> str:
-    """Format a task as a tab-separated plain row."""
-    due = task.due.date if task.due else ""
+def _task_plain_row(
+    task: Task,
+    project_names: dict[str, str] | None = None,
+    *,
+    show_project: bool = True,
+    show_labels: bool = True,
+) -> str:
+    """Format a task as a tab-separated plain row.
+
+    Column order matches Rich: PRI, CONTENT, PROJECT, DUE, LABELS.
+    """
+    due = str(task.due.date) if task.due else ""
     priority = f"p{5 - task.priority}" if task.priority else ""
-    labels = ",".join(task.labels) if task.labels else ""
-    project = project_names.get(task.project_id, "") if project_names else ""
-    return f"{task.content}\t{project}\t{due}\t{priority}\t{labels}"
+    parts = [priority, task.content]
+    if show_project:
+        project = project_names.get(task.project_id, "") if project_names else ""
+        parts.append(project)
+    parts.append(due)
+    if show_labels:
+        labels = ",".join(task.labels) if task.labels else ""
+        parts.append(labels)
+    return "\t".join(parts)
 
 
 class OutputFormatter:
@@ -143,7 +210,8 @@ class OutputFormatter:
             lines.append(f"[dim]Project:[/dim]  {project_name}")
         lines.append(f"[dim]Priority:[/dim] [{p_style}]{p_label}[/{p_style}]")
         if task.due:
-            lines.append(f"[dim]Due:[/dim]      [yellow]{task.due.string}[/yellow]")
+            due_style = "red" if _is_overdue(str(task.due.date)) else "yellow"
+            lines.append(f"[dim]Due:[/dim]      [{due_style}]{task.due.string}[/{due_style}]")
         if task.labels:
             lbl_str = ", ".join(f"[cyan]@{lbl}[/cyan]" for lbl in task.labels)
             lines.append(f"[dim]Labels:[/dim]   {lbl_str}")
@@ -171,30 +239,57 @@ class OutputFormatter:
         # Cache task IDs for numbered references (td done 1, etc.)
         save_result_cache([t.id for t in tasks])
 
+        if not tasks:
+            if self.mode == OutputMode.JSON:
+                self._json_out([], "task_list")
+            elif self.mode == OutputMode.PLAIN:
+                click.echo(_empty_message("tasks"))
+            else:
+                assert self._console is not None
+                self._console.print(f"[dim]{_empty_message('tasks')}[/dim]")
+            return
+
+        # Smart column visibility (same logic for Rich and Plain)
+        has_labels = any(t.labels for t in tasks) if show_labels is None else show_labels
+        has_project = project_names is not None if show_project is None else show_project
+
         if self.mode == OutputMode.JSON:
             self._json_out([_task_to_dict(t, project_names) for t in tasks], "task_list")
         elif self.mode == OutputMode.PLAIN:
-            click.echo("#\tCONTENT\tPROJECT\tDUE\tPRIORITY\tLABELS")
+            header_parts = ["#", "PRI", "CONTENT"]
+            if has_project:
+                header_parts.append("PROJECT")
+            header_parts.append("DUE")
+            if has_labels:
+                header_parts.append("LABELS")
+            click.echo("\t".join(header_parts))
             for i, t in enumerate(tasks, 1):
-                click.echo(f"{i}\t{_task_plain_row(t, project_names)}")
+                row = _task_plain_row(
+                    t,
+                    project_names,
+                    show_project=has_project,
+                    show_labels=has_labels,
+                )
+                click.echo(f"{i}\t{row}")
         else:
             self._rich_task_table(
                 tasks,
                 title,
                 project_names,
-                show_labels=show_labels,
-                show_project=show_project,
+                show_labels=has_labels,
+                show_project=has_project,
             )
 
     def _rich_task(self, task: Task) -> None:
         assert self._console is not None
         text = Text()
         p_label, p_style = _PRIORITY_STYLES.get(task.priority, ("p4", "dim"))
-        text.append("▎ ", style=p_style)
+        text.append("\u258e ", style=p_style)
         text.append(p_label, style=p_style)
         text.append(f"  {task.content}")
         if task.due:
-            text.append(f"  {task.due.string}", style="yellow")
+            due_style = "red" if _is_overdue(str(task.due.date)) else "yellow"
+            text.append(f"  {task.due.string}", style=due_style)
         if task.labels:
             for label in task.labels:
                 text.append(f" @{label}", style="cyan")
@@ -205,40 +300,37 @@ class OutputFormatter:
         tasks: list[Task],
         title: str | None = None,
         project_names: dict[str, str] | None = None,
-        show_labels: bool | None = None,
-        show_project: bool | None = None,
+        show_labels: bool = False,
+        show_project: bool = False,
     ) -> None:
         assert self._console is not None
-
-        # Smart column visibility
-        has_labels = any(t.labels for t in tasks) if show_labels is None else show_labels
-        has_project = project_names is not None if show_project is None else show_project
 
         table = Table(title=title or "Tasks", show_lines=False)
         table.add_column("#", style="dim", width=3)
         table.add_column("", width=2)  # priority bar
         table.add_column("Pri", width=3)
         table.add_column("Content")
-        if has_project:
+        if show_project:
             table.add_column("Project", style="dim")
-        table.add_column("Due", style="yellow")
-        if has_labels:
+        table.add_column("Due")
+        if show_labels:
             table.add_column("Labels", style="cyan")
 
         for i, task in enumerate(tasks, 1):
             p_label, p_style = _PRIORITY_STYLES.get(task.priority, ("p4", "dim"))
-            due = task.due.string if task.due else ""
+            due_str = task.due.string if task.due else ""
+            due_style = "red" if task.due and _is_overdue(str(task.due.date)) else "yellow"
             row: list[str | Text] = [
                 str(i),
-                Text("▎", style=p_style),
+                Text("\u258e", style=p_style),
                 Text(p_label, style=p_style),
                 task.content,
             ]
-            if has_project:
+            if show_project:
                 project = project_names.get(task.project_id, "") if project_names else ""
                 row.append(project)
-            row.append(due)
-            if has_labels:
+            row.append(Text(due_str, style=due_style))
+            if show_labels:
                 labels = ", ".join(f"@{lbl}" for lbl in task.labels) if task.labels else ""
                 row.append(labels)
             table.add_row(*row)
@@ -249,12 +341,23 @@ class OutputFormatter:
 
     def project_list(self, projects: list[Project]) -> None:
         """Render a list of projects."""
+        if not projects:
+            if self.mode == OutputMode.JSON:
+                self._json_out([], "project_list")
+            elif self.mode == OutputMode.PLAIN:
+                click.echo(_empty_message("projects"))
+            else:
+                assert self._console is not None
+                self._console.print(f"[dim]{_empty_message('projects')}[/dim]")
+            return
+
         if self.mode == OutputMode.JSON:
             self._json_out([p.to_dict() for p in projects], "project_list")
         elif self.mode == OutputMode.PLAIN:
-            click.echo("ID\tNAME")
+            click.echo("NAME\t\u2605\tID")
             for p in projects:
-                click.echo(f"{p.id}\t{p.name}")
+                fav = "*" if p.is_favorite else ""
+                click.echo(f"{p.name}\t{fav}\t{p.id}")
         else:
             self._rich_project_table(projects)
 
@@ -262,12 +365,12 @@ class OutputFormatter:
         assert self._console is not None
         table = Table(title="Projects")
         table.add_column("Name", style="bold")
+        table.add_column("\u2605", width=3)
         table.add_column("ID", style="dim")
-        table.add_column("", width=3)
 
         for p in projects:
             fav = "*" if p.is_favorite else ""
-            table.add_row(p.name, p.id, fav)
+            table.add_row(p.name, fav, p.id)
 
         self._console.print(table)
 
@@ -275,12 +378,22 @@ class OutputFormatter:
 
     def section_list(self, sections: list[Section]) -> None:
         """Render a list of sections."""
+        if not sections:
+            if self.mode == OutputMode.JSON:
+                self._json_out([], "section_list")
+            elif self.mode == OutputMode.PLAIN:
+                click.echo(_empty_message("sections"))
+            else:
+                assert self._console is not None
+                self._console.print(f"[dim]{_empty_message('sections')}[/dim]")
+            return
+
         if self.mode == OutputMode.JSON:
             self._json_out([s.to_dict() for s in sections], "section_list")
         elif self.mode == OutputMode.PLAIN:
-            click.echo("ID\tNAME")
+            click.echo("NAME\tID")
             for s in sections:
-                click.echo(f"{s.id}\t{s.name}")
+                click.echo(f"{s.name}\t{s.id}")
         else:
             self._rich_section_table(sections)
 
@@ -299,12 +412,22 @@ class OutputFormatter:
 
     def label_list(self, labels: list[Label]) -> None:
         """Render a list of labels."""
+        if not labels:
+            if self.mode == OutputMode.JSON:
+                self._json_out([], "label_list")
+            elif self.mode == OutputMode.PLAIN:
+                click.echo(_empty_message("labels"))
+            else:
+                assert self._console is not None
+                self._console.print(f"[dim]{_empty_message('labels')}[/dim]")
+            return
+
         if self.mode == OutputMode.JSON:
             self._json_out([lbl.to_dict() for lbl in labels], "label_list")
         elif self.mode == OutputMode.PLAIN:
-            click.echo("ID\tNAME")
+            click.echo("NAME\tID")
             for lbl in labels:
-                click.echo(f"{lbl.id}\t{lbl.name}")
+                click.echo(f"@{lbl.name}\t{lbl.id}")
         else:
             self._rich_label_table(labels)
 
@@ -316,6 +439,43 @@ class OutputFormatter:
 
         for lbl in labels:
             table.add_row(f"@{lbl.name}", lbl.id)
+
+        self._console.print(table)
+
+    # --- Comments ---
+
+    def comment_list(self, comments: list[Comment]) -> None:
+        """Render a list of comments."""
+        if not comments:
+            if self.mode == OutputMode.JSON:
+                self._json_out([], "comment_list")
+            elif self.mode == OutputMode.PLAIN:
+                click.echo(_empty_message("comments"))
+            else:
+                assert self._console is not None
+                self._console.print(f"[dim]{_empty_message('comments')}[/dim]")
+            return
+
+        if self.mode == OutputMode.JSON:
+            self._json_out([c.to_dict() for c in comments], "comment_list")
+        elif self.mode == OutputMode.PLAIN:
+            click.echo("CONTENT\tPOSTED\tID")
+            for c in comments:
+                posted = _format_timestamp(str(c.posted_at))
+                click.echo(f"{c.content}\t{posted}\t{c.id}")
+        else:
+            self._rich_comment_table(comments)
+
+    def _rich_comment_table(self, comments: list[Comment]) -> None:
+        assert self._console is not None
+        table = Table(title="Comments", show_lines=False)
+        table.add_column("Content", style="bold")
+        table.add_column("Posted", style="dim")
+        table.add_column("ID", style="dim")
+
+        for c in comments:
+            posted = _format_timestamp(str(c.posted_at))
+            table.add_row(c.content, posted, c.id)
 
         self._console.print(table)
 

--- a/src/td/cli/tasks.py
+++ b/src/td/cli/tasks.py
@@ -385,7 +385,8 @@ def log(ctx: click.Context, week: bool) -> None:
         for page in api.get_completed_tasks_by_completion_date(since=since, until=now)
         for t in page
     ]
-    fmt.task_list(completed, title=title)
+    pnames = get_project_name_map(api)
+    fmt.task_list(completed, title=title, project_names=pnames)
 
 
 @click.command()
@@ -658,7 +659,8 @@ def search(ctx: click.Context, query: tuple[str, ...], project_name: str | None)
         return 2
 
     tasks.sort(key=relevance)
-    fmt.task_list(tasks)
+    pnames = get_project_name_map(api)
+    fmt.task_list(tasks, project_names=pnames)
 
 
 @click.command()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -3,9 +3,17 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
-from td.cli.output import OutputFormatter, OutputMode, resolve_output_mode
+from td.cli.output import (
+    OutputFormatter,
+    OutputMode,
+    _empty_message,
+    _format_timestamp,
+    _is_overdue,
+    resolve_output_mode,
+)
 
 
 def _make_task(**overrides: object) -> MagicMock:
@@ -65,6 +73,19 @@ def _make_section(**overrides: object) -> MagicMock:
     return sec
 
 
+def _make_comment(**overrides: object) -> MagicMock:
+    comment = MagicMock()
+    comment.id = overrides.get("id", "comment1")
+    comment.content = overrides.get("content", "Looking good!")
+    comment.posted_at = overrides.get("posted_at", "2026-04-01T12:00:00Z")
+    comment.to_dict.return_value = {
+        "id": comment.id,
+        "content": comment.content,
+        "posted_at": comment.posted_at,
+    }
+    return comment
+
+
 class TestResolveOutputMode:
     def test_json_flag(self) -> None:
         assert resolve_output_mode(True, False) == OutputMode.JSON
@@ -105,6 +126,52 @@ class TestResolveOutputMode:
         # Falls through to TTY detection
         mode = resolve_output_mode(False, False, default_format="invalid")
         assert mode in (OutputMode.RICH, OutputMode.JSON)
+
+
+class TestHelpers:
+    def test_is_overdue_past_date(self) -> None:
+        assert _is_overdue("2020-01-01") is True
+
+    def test_is_overdue_future_date(self) -> None:
+        assert _is_overdue("2099-12-31") is False
+
+    def test_is_overdue_invalid_date(self) -> None:
+        assert _is_overdue("not-a-date") is False
+
+    def test_format_timestamp_minutes_ago(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        recent = (now - timedelta(minutes=5)).isoformat()
+        result = _format_timestamp(recent)
+        assert result.endswith("m ago")
+
+    def test_format_timestamp_hours_ago(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        hours_ago = (now - timedelta(hours=3)).isoformat()
+        result = _format_timestamp(hours_ago)
+        assert result.endswith("h ago")
+
+    def test_format_timestamp_days_ago(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        days_ago = (now - timedelta(days=3)).isoformat()
+        result = _format_timestamp(days_ago)
+        assert result.endswith("d ago")
+
+    def test_format_timestamp_old_date(self) -> None:
+        result = _format_timestamp("2025-01-15T12:00:00+00:00")
+        assert "Jan" in result and "15" in result
+
+    def test_format_timestamp_invalid(self) -> None:
+        result = _format_timestamp("not-a-timestamp")
+        assert result == "not-a-timestamp"
+
+    def test_empty_message_tasks(self) -> None:
+        assert _empty_message("tasks") == "No tasks found."
+
+    def test_empty_message_projects(self) -> None:
+        assert _empty_message("projects") == "No projects found."
+
+    def test_empty_message_unknown(self) -> None:
+        assert _empty_message("widgets") == "No widgets found."
 
 
 class TestJsonOutput:
@@ -184,29 +251,130 @@ class TestJsonOutput:
         data = json.loads(captured.out)
         assert data["data"]["created"] is False
 
+    def test_comment_list_json(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.JSON)
+        comments = [_make_comment(content="Great work")]
+        fmt.comment_list(comments)
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        data = json.loads(captured.out)
+        assert data["type"] == "comment_list"
+        assert len(data["data"]) == 1
+
+    def test_empty_task_list_json(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.JSON)
+        fmt.task_list([])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        data = json.loads(captured.out)
+        assert data["ok"] is True
+        assert data["data"] == []
+
+    def test_empty_project_list_json(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.JSON)
+        fmt.project_list([])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        data = json.loads(captured.out)
+        assert data["data"] == []
+
+    def test_empty_comment_list_json(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.JSON)
+        fmt.comment_list([])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        data = json.loads(captured.out)
+        assert data["data"] == []
+
 
 class TestPlainOutput:
     def test_task_list_plain(self, capsys: object) -> None:
         fmt = OutputFormatter(OutputMode.PLAIN)
         tasks = [
-            _make_task(content="Buy milk", due="2026-03-25"),
+            _make_task(content="Buy milk", due="2026-03-25", labels=["errands"]),
             _make_task(content="Code review", priority=4),
         ]
+        pnames = {"proj1": "Work"}
+        fmt.task_list(tasks, project_names=pnames)
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        lines = captured.out.strip().split("\n")
+        assert lines[0] == "#\tPRI\tCONTENT\tPROJECT\tDUE\tLABELS"
+        assert "Buy milk" in lines[1]
+        assert "\t" in lines[1]
+
+    def test_task_list_plain_no_project(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        tasks = [_make_task(content="Buy milk")]
+        fmt.task_list(tasks, show_project=False)
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        lines = captured.out.strip().split("\n")
+        assert "PROJECT" not in lines[0]
+
+    def test_task_list_plain_no_labels(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        tasks = [_make_task(content="Buy milk")]
+        fmt.task_list(tasks, show_labels=False)
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        lines = captured.out.strip().split("\n")
+        assert "LABELS" not in lines[0]
+
+    def test_task_list_plain_smart_hide_labels(self, capsys: object) -> None:
+        """When no tasks have labels, LABELS column is auto-hidden."""
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        tasks = [_make_task(content="No labels", labels=[])]
         fmt.task_list(tasks)
 
         captured = capsys.readouterr()  # type: ignore[union-attr]
         lines = captured.out.strip().split("\n")
-        assert lines[0] == "#\tCONTENT\tPROJECT\tDUE\tPRIORITY\tLABELS"
-        assert "Buy milk" in lines[1]
-        assert "\t" in lines[1]
+        assert "LABELS" not in lines[0]
 
     def test_project_list_plain(self, capsys: object) -> None:
         fmt = OutputFormatter(OutputMode.PLAIN)
-        fmt.project_list([_make_project(name="Work")])
+        fmt.project_list([_make_project(name="Work", is_favorite=True)])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        lines = captured.out.strip().split("\n")
+        assert lines[0] == "NAME\t\u2605\tID"
+        assert "Work" in lines[1]
+        assert "*" in lines[1]
+
+    def test_project_list_plain_no_favorite(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        fmt.project_list([_make_project(name="Work", is_favorite=False)])
 
         captured = capsys.readouterr()  # type: ignore[union-attr]
         lines = captured.out.strip().split("\n")
         assert "Work" in lines[1]
+
+    def test_label_list_plain_at_prefix(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        fmt.label_list([_make_label(name="urgent")])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        lines = captured.out.strip().split("\n")
+        assert lines[0] == "NAME\tID"
+        assert "@urgent" in lines[1]
+
+    def test_section_list_plain_name_first(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        fmt.section_list([_make_section(name="In Progress", id="sec1")])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        lines = captured.out.strip().split("\n")
+        assert lines[0] == "NAME\tID"
+        assert lines[1].startswith("In Progress")
+
+    def test_comment_list_plain(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        fmt.comment_list([_make_comment(content="Nice!", posted_at="2026-04-01T12:00:00Z")])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        lines = captured.out.strip().split("\n")
+        assert lines[0] == "CONTENT\tPOSTED\tID"
+        assert "Nice!" in lines[1]
 
     def test_success_plain(self, capsys: object) -> None:
         fmt = OutputFormatter(OutputMode.PLAIN)
@@ -214,6 +382,41 @@ class TestPlainOutput:
 
         captured = capsys.readouterr()  # type: ignore[union-attr]
         assert captured.out.strip() == "Task completed"
+
+    def test_empty_task_list_plain(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        fmt.task_list([])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        assert captured.out.strip() == "No tasks found."
+
+    def test_empty_project_list_plain(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        fmt.project_list([])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        assert captured.out.strip() == "No projects found."
+
+    def test_empty_label_list_plain(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        fmt.label_list([])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        assert captured.out.strip() == "No labels found."
+
+    def test_empty_section_list_plain(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        fmt.section_list([])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        assert captured.out.strip() == "No sections found."
+
+    def test_empty_comment_list_plain(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        fmt.comment_list([])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        assert captured.out.strip() == "No comments found."
 
 
 class TestRichOutput:
@@ -236,3 +439,38 @@ class TestRichOutput:
     def test_success_renders(self) -> None:
         fmt = OutputFormatter(OutputMode.RICH)
         fmt.success("All done!")
+
+    def test_comment_list_renders(self) -> None:
+        fmt = OutputFormatter(OutputMode.RICH)
+        fmt.comment_list([_make_comment()])
+
+    def test_empty_task_list_renders(self) -> None:
+        fmt = OutputFormatter(OutputMode.RICH)
+        fmt.task_list([])
+
+    def test_empty_project_list_renders(self) -> None:
+        fmt = OutputFormatter(OutputMode.RICH)
+        fmt.project_list([])
+
+    def test_empty_label_list_renders(self) -> None:
+        fmt = OutputFormatter(OutputMode.RICH)
+        fmt.label_list([])
+
+    def test_empty_section_list_renders(self) -> None:
+        fmt = OutputFormatter(OutputMode.RICH)
+        fmt.section_list([])
+
+    def test_empty_comment_list_renders(self) -> None:
+        fmt = OutputFormatter(OutputMode.RICH)
+        fmt.comment_list([])
+
+    def test_overdue_task_renders(self) -> None:
+        fmt = OutputFormatter(OutputMode.RICH)
+        task = _make_task(content="Overdue task", priority=4, due="2020-01-01")
+        # Should render without exception — overdue styling applied
+        fmt.task(task)
+
+    def test_overdue_task_list_renders(self) -> None:
+        fmt = OutputFormatter(OutputMode.RICH)
+        tasks = [_make_task(content="Overdue", due="2020-01-01")]
+        fmt.task_list(tasks)


### PR DESCRIPTION
## Related issues

Closes #112

## What

- **Column consistency**: Rich and Plain modes now use same column order for all list views (tasks, projects, labels, sections, comments)
- **Smart column hiding in Plain**: PROJECT/LABELS columns hidden when not relevant (inbox, focus, no labels) — previously only Rich mode did this
- **Search/log project context**: `td search` and `td log` now show project names
- **Human-readable timestamps**: Comments show "2h ago", "3d ago", "Apr 10" instead of raw ISO
- **Comment rendering**: Moved into `OutputFormatter.comment_list()` for consistency
- **Empty states**: "No tasks found." instead of empty tables across all list views
- **Overdue styling**: Overdue dates in red, non-overdue in yellow (Rich mode)
- **Label `@` prefix**: Consistent in both Rich and Plain modes
- 35 new tests

## Why

Users build a mental model of what to expect from CLI output. Inconsistent column orders between modes, missing project context in search results, raw ISO timestamps, and empty tables all break that model. This makes every list view consistent so users can trust the output format regardless of context.

## How to test

- `td ls --plain` vs `td ls` — same column order
- `td search <term>` — project column now shown
- `td comments <ref>` — human-readable timestamps
- `td inbox` with no tasks — helpful empty state message
- 243 tests pass, 89% coverage

## Checklist

- [x] `make check` passes (lint + tests) — 243 passed, 89% coverage
- [x] CHANGELOG.md updated under `[Unreleased]` (Changed)
- [ ] Bug fixes include a regression test — N/A (feature)
- [ ] Help text updated for new/changed commands — N/A (output formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)