### PR TITLE
fix(errors): audit and improve all error paths for human-readable messaging

### DIFF
--- a/src/td/cli/__init__.py
+++ b/src/td/cli/__init__.py
@@ -33,6 +33,7 @@ class TdGroup(click.Group):
         except Exception as e:
             if isinstance(e, click.ClickException | SystemExit):
                 raise
+            # Handle network/httpx errors and any other unhandled exceptions
             td_error = map_api_exception(e)
             mode = self._get_mode(ctx)
             handle_error(td_error, mode)

--- a/src/td/cli/errors.py
+++ b/src/td/cli/errors.py
@@ -20,6 +20,11 @@ LABEL_NOT_FOUND = "LABEL_NOT_FOUND"
 VALIDATION_ERROR = "VALIDATION_ERROR"
 API_ERROR = "API_ERROR"
 API_RATE_LIMIT = "API_RATE_LIMIT"
+API_FORBIDDEN = "API_FORBIDDEN"
+API_TIMEOUT = "API_TIMEOUT"
+API_SERVER_ERROR = "API_SERVER_ERROR"
+NETWORK_ERROR = "NETWORK_ERROR"
+CACHE_ERROR = "CACHE_ERROR"
 DUPLICATE_TASK = "DUPLICATE_TASK"
 
 
@@ -114,6 +119,43 @@ class TdRateLimitError(TdError):
     suggestion = "Wait a moment and try again. Todoist allows 450 requests per 15 minutes."
 
 
+class TdForbiddenError(TdError):
+    """Access forbidden."""
+
+    code = API_FORBIDDEN
+    suggestion = "Check your permissions for this resource in Todoist."
+
+
+class TdTimeoutError(TdError):
+    """Request timed out."""
+
+    code = API_TIMEOUT
+    suggestion = "Check your internet connection and try again."
+
+
+class TdServerError(TdError):
+    """Todoist server error."""
+
+    code = API_SERVER_ERROR
+    suggestion = "Todoist may be experiencing issues. Try again in a few minutes."
+
+
+class TdNetworkError(TdError):
+    """Network connectivity error."""
+
+    code = NETWORK_ERROR
+    suggestion = (
+        "Check your internet connection. "
+        "If the problem persists, check https://status.todoist.com for service status."
+    )
+
+
+class TdCacheError(TdError):
+    """Cache read/write error."""
+
+    code = CACHE_ERROR
+
+
 def handle_error(error: TdError, mode: OutputMode) -> None:
     """Render a TdError to stderr in the appropriate output mode."""
     if mode == OutputMode.JSON:
@@ -149,25 +191,36 @@ def _extract_response_detail(exc: Exception) -> str:
 
 def map_api_exception(exc: Exception) -> TdError:
     """Map SDK/httpx exceptions to structured TdError subclasses."""
-    from httpx import HTTPStatusError
+    import httpx
 
-    if isinstance(exc, HTTPStatusError):
+    # Network-level errors (no HTTP response received)
+    if isinstance(exc, httpx.ConnectTimeout):
+        return TdTimeoutError(
+            "Connection timed out while reaching Todoist.",
+            suggestion="Check your internet connection and try again.",
+        )
+    if isinstance(exc, httpx.ReadTimeout):
+        return TdTimeoutError(
+            "Request timed out waiting for Todoist to respond.",
+            suggestion="Todoist may be slow. Try again in a moment.",
+        )
+    if isinstance(exc, httpx.ConnectError):
+        return TdNetworkError(
+            "Could not connect to Todoist API.",
+            suggestion=(
+                "Check your internet connection. "
+                "If the problem persists, check https://status.todoist.com for service status."
+            ),
+        )
+    if isinstance(exc, httpx.TimeoutException):
+        return TdTimeoutError(
+            "Request to Todoist timed out.",
+            suggestion="Check your internet connection and try again.",
+        )
+
+    # HTTP status errors (response received with error code)
+    if isinstance(exc, httpx.HTTPStatusError):
         status = exc.response.status_code
-        if status == 401:
-            return TdAuthError(
-                "Invalid API token.",
-                code=AUTH_INVALID,
-                suggestion="Check your token at https://app.todoist.com/app/settings/integrations/developer",
-            )
-        if status == 403:
-            return TdApiError(
-                "Access forbidden.",
-                suggestion="Check your permissions for this resource.",
-            )
-        if status == 404:
-            return TdNotFoundError("Resource not found.")
-        if status == 429:
-            return TdRateLimitError("Rate limit exceeded.")
         if status == 400:
             detail = _extract_response_detail(exc)
             message = f"Bad request: {detail}" if detail else "Bad request to Todoist API."
@@ -176,32 +229,125 @@ def map_api_exception(exc: Exception) -> TdError:
                 suggestion="Check command arguments. Use --help for usage details.",
                 details={"status_code": status},
             )
-        # Generic fallback — try to extract a useful message from the response
+        if status == 401:
+            return TdAuthError(
+                "Invalid API token.",
+                code=AUTH_INVALID,
+                suggestion="Check your token at https://app.todoist.com/app/settings/integrations/developer",
+            )
+        if status == 403:
+            return TdForbiddenError(
+                "Access forbidden. You don't have permission for this resource.",
+                suggestion="Check your permissions for this resource in Todoist.",
+            )
+        if status == 404:
+            detail = _extract_response_detail(exc)
+            message = f"Resource not found: {detail}" if detail else "Resource not found."
+            return TdNotFoundError(
+                message,
+                suggestion="Verify the task, project, or label exists. "
+                "Use `td ls` or `td projects` to see available items.",
+            )
+        if status == 408:
+            return TdTimeoutError(
+                "Request timed out on the server side.",
+                suggestion="Try again. If the problem persists, Todoist may be under heavy load.",
+                details={"status_code": status},
+            )
+        if status == 429:
+            return TdRateLimitError("Rate limit exceeded.")
+        if status == 500:
+            detail = _extract_response_detail(exc)
+            message = (
+                f"Todoist internal server error: {detail}"
+                if detail
+                else "Todoist internal server error."
+            )
+            return TdServerError(
+                message,
+                suggestion="This is a Todoist server issue. Try again in a few minutes.",
+                details={"status_code": status},
+            )
+        if status == 502:
+            return TdServerError(
+                "Todoist returned a bad gateway error.",
+                suggestion="Todoist may be deploying updates. Try again in a minute.",
+                details={"status_code": status},
+            )
+        if status == 503:
+            return TdServerError(
+                "Todoist is temporarily unavailable.",
+                suggestion="Todoist is down for maintenance or overloaded. "
+                "Check https://status.todoist.com and try again later.",
+                details={"status_code": status},
+            )
+        if status == 504:
+            return TdServerError(
+                "Todoist gateway timed out.",
+                suggestion="Todoist is responding slowly. Try again in a few minutes.",
+                details={"status_code": status},
+            )
+        # Generic fallback for other HTTP errors
         detail = _extract_response_detail(exc)
-        message = f"API error: {detail}" if detail else f"API error ({status})."
+        message = f"API error: {detail}" if detail else f"API error (HTTP {status})."
         return TdApiError(
             message,
-            suggestion="Try again or check https://todoist.com/help for service status.",
+            suggestion="Try again or check https://status.todoist.com for service status.",
             details={"status_code": status},
         )
 
-    return TdApiError(f"Unexpected error: {exc}")
+    return TdApiError(
+        f"Unexpected error: {exc}",
+        suggestion="If this persists, run with TD_DEBUG=1 for more details.",
+    )
 
 
 def map_core_exception(exc: Exception) -> TdError:
     """Map a core-layer exception to a CLI TdError, preserving code/message/suggestion."""
-    from td.core.exceptions import AuthError, TdCoreError
+    from td.core.exceptions import (
+        AuthError,
+        LabelNotFoundError,
+        ProjectNotFoundError,
+        SectionNotFoundError,
+        TdCoreError,
+    )
 
     if not isinstance(exc, TdCoreError):
-        return TdApiError(f"Unexpected error: {exc}")
+        return TdApiError(
+            f"Unexpected error: {exc}",
+            suggestion="If this persists, run with TD_DEBUG=1 for more details.",
+        )
 
     if isinstance(exc, AuthError):
         return TdAuthError(exc.message, suggestion=exc.suggestion)
+
+    if isinstance(exc, ProjectNotFoundError):
+        return TdProjectNotFoundError(
+            exc.message,
+            suggestion=exc.suggestion or "Run `td projects` to list available projects.",
+            details=exc.details,
+        )
+
+    if isinstance(exc, SectionNotFoundError):
+        return TdNotFoundError(
+            exc.message,
+            code=SECTION_NOT_FOUND,
+            suggestion=exc.suggestion or "Run `td sections -p <project>` to list sections.",
+            details=exc.details,
+        )
+
+    if isinstance(exc, LabelNotFoundError):
+        return TdNotFoundError(
+            exc.message,
+            code=LABEL_NOT_FOUND,
+            suggestion=exc.suggestion or "Run `td labels` to list available labels.",
+            details=exc.details,
+        )
 
     # Generic mapping — preserves code, message, suggestion, and details
     return TdError(
         exc.message,
         code=exc.code,
-        suggestion=exc.suggestion,
+        suggestion=exc.suggestion or "If this persists, run with TD_DEBUG=1 for more details.",
         details=exc.details,
     )

--- a/src/td/core/cache.py
+++ b/src/td/core/cache.py
@@ -86,7 +86,7 @@ def load_result_cache(max_age: int | None = None) -> dict[str, str]:
             return {}
         ids: dict[str, str] = data.get("ids", {})
         return ids
-    except (json.JSONDecodeError, KeyError):
+    except (json.JSONDecodeError, KeyError, OSError):
         return {}
 
 
@@ -150,5 +150,5 @@ def load_name_cache(max_age: int | None = None) -> dict[str, Any]:
             return {}
         result: dict[str, Any] = data
         return result
-    except (json.JSONDecodeError, KeyError):
+    except (json.JSONDecodeError, KeyError, OSError):
         return {}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -5,11 +5,21 @@ from __future__ import annotations
 import json
 
 from td.cli.errors import (
+    API_FORBIDDEN,
+    API_SERVER_ERROR,
+    API_TIMEOUT,
+    NETWORK_ERROR,
     TdApiError,
     TdAuthError,
+    TdCacheError,
     TdError,
+    TdForbiddenError,
+    TdNetworkError,
     TdNotFoundError,
+    TdProjectNotFoundError,
     TdRateLimitError,
+    TdServerError,
+    TdTimeoutError,
     TdValidationError,
     handle_error,
     map_api_exception,
@@ -32,6 +42,17 @@ class TestTdError:
         assert data["error"]["message"] == "Something broke"
         assert data["error"]["suggestion"] == "Try again"
         assert data["error"]["details"]["key"] == "value"
+
+    def test_json_envelope_always_has_required_fields(self) -> None:
+        """Every JSON error must include ok, error.code, error.message, error.suggestion."""
+        err = TdError("minimal error")
+        data = json.loads(err.format_json())
+        assert data["ok"] is False
+        error = data["error"]
+        assert "code" in error
+        assert "message" in error
+        assert "suggestion" in error
+        assert "details" in error
 
     def test_plain_format(self) -> None:
         err = TdError("Bad input", suggestion="Check your args")
@@ -64,6 +85,36 @@ class TestErrorSubclasses:
         err = TdRateLimitError("Slow down")
         assert err.code == "API_RATE_LIMIT"
         assert "450" in err.suggestion
+
+    def test_forbidden_error_defaults(self) -> None:
+        err = TdForbiddenError("No access")
+        assert err.code == API_FORBIDDEN
+        assert "permissions" in err.suggestion.lower()
+
+    def test_timeout_error_defaults(self) -> None:
+        err = TdTimeoutError("Timed out")
+        assert err.code == API_TIMEOUT
+        assert "internet" in err.suggestion.lower() or "try again" in err.suggestion.lower()
+
+    def test_server_error_defaults(self) -> None:
+        err = TdServerError("Server down")
+        assert err.code == API_SERVER_ERROR
+        assert "try again" in err.suggestion.lower()
+
+    def test_network_error_defaults(self) -> None:
+        err = TdNetworkError("No connection")
+        assert err.code == NETWORK_ERROR
+        assert "internet" in err.suggestion.lower()
+
+    def test_cache_error(self) -> None:
+        err = TdCacheError("Cache corrupt", suggestion="Delete cache and retry.")
+        assert err.code == "CACHE_ERROR"
+        assert err.suggestion == "Delete cache and retry."
+
+    def test_project_not_found_error(self) -> None:
+        err = TdProjectNotFoundError("Project 'X' not found")
+        assert err.code == "PROJECT_NOT_FOUND"
+        assert "td projects" in err.suggestion
 
 
 class TestHandleError:
@@ -105,10 +156,31 @@ class TestMapApiException:
         assert isinstance(result, TdAuthError)
         assert result.code == "AUTH_INVALID"
 
+    def test_403_maps_to_forbidden(self) -> None:
+        exc = self._make_status_error(403, "Forbidden")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdForbiddenError)
+        assert result.code == API_FORBIDDEN
+        assert "permission" in result.suggestion.lower()
+
     def test_404_maps_to_not_found(self) -> None:
         exc = self._make_status_error(404, "Not Found")
         result = map_api_exception(exc)
         assert isinstance(result, TdNotFoundError)
+        assert result.suggestion != ""
+
+    def test_404_extracts_detail(self) -> None:
+        exc = self._make_status_error(404, "Not Found", body="Task not found")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdNotFoundError)
+        assert "Task not found" in result.message
+
+    def test_408_maps_to_timeout(self) -> None:
+        exc = self._make_status_error(408, "Request Timeout")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdTimeoutError)
+        assert result.code == API_TIMEOUT
+        assert "try again" in result.suggestion.lower()
 
     def test_429_maps_to_rate_limit(self) -> None:
         exc = self._make_status_error(429, "Too Many Requests")
@@ -134,25 +206,85 @@ class TestMapApiException:
         assert isinstance(result, TdValidationError)
         assert "Missing required field" in result.message
 
-    def test_500_maps_to_api_error(self) -> None:
+    def test_500_maps_to_server_error(self) -> None:
         exc = self._make_status_error(500, "Internal Server Error")
         result = map_api_exception(exc)
-        assert isinstance(result, TdApiError)
-
-    def test_500_includes_suggestion(self) -> None:
-        exc = self._make_status_error(500, "Internal Server Error")
-        result = map_api_exception(exc)
-        assert result.suggestion != ""
+        assert isinstance(result, TdServerError)
+        assert result.code == API_SERVER_ERROR
+        assert "try again" in result.suggestion.lower()
 
     def test_500_extracts_response_body(self) -> None:
         exc = self._make_status_error(500, "Server Error", body='{"error": "DB timeout"}')
         result = map_api_exception(exc)
         assert "DB timeout" in result.message
 
+    def test_502_maps_to_server_error(self) -> None:
+        exc = self._make_status_error(502, "Bad Gateway")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdServerError)
+        assert "bad gateway" in result.message.lower()
+        assert "try again" in result.suggestion.lower()
+
+    def test_503_maps_to_server_error(self) -> None:
+        exc = self._make_status_error(503, "Service Unavailable")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdServerError)
+        assert "unavailable" in result.message.lower()
+        assert "status.todoist.com" in result.suggestion
+
+    def test_504_maps_to_server_error(self) -> None:
+        exc = self._make_status_error(504, "Gateway Timeout")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdServerError)
+        assert "gateway timed out" in result.message.lower()
+        assert "try again" in result.suggestion.lower()
+
+    def test_unknown_http_status_fallback(self) -> None:
+        exc = self._make_status_error(418, "I'm a teapot")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdApiError)
+        assert result.details.get("status_code") == 418
+        assert "status.todoist.com" in result.suggestion
+
     def test_unknown_exception(self) -> None:
         result = map_api_exception(ValueError("weird"))
         assert isinstance(result, TdApiError)
         assert "weird" in result.message
+        assert "TD_DEBUG" in result.suggestion
+
+    def test_connect_timeout(self) -> None:
+        import httpx
+
+        exc = httpx.ConnectTimeout("Connection timed out")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdTimeoutError)
+        assert "connection" in result.message.lower()
+        assert "internet" in result.suggestion.lower()
+
+    def test_read_timeout(self) -> None:
+        import httpx
+
+        exc = httpx.ReadTimeout("Read timed out")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdTimeoutError)
+        assert "timed out" in result.message.lower()
+
+    def test_connect_error(self) -> None:
+        import httpx
+
+        exc = httpx.ConnectError("Connection refused")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdNetworkError)
+        assert "connect" in result.message.lower()
+        assert "internet" in result.suggestion.lower()
+
+    def test_generic_timeout_exception(self) -> None:
+        import httpx
+
+        exc = httpx.PoolTimeout("Pool timed out")
+        result = map_api_exception(exc)
+        assert isinstance(result, TdTimeoutError)
+        assert "timed out" in result.message.lower()
 
 
 class TestMapCoreException:
@@ -164,7 +296,7 @@ class TestMapCoreException:
         assert isinstance(result, TdAuthError)
         assert "td init" in result.suggestion
 
-    def test_project_not_found_preserves_fields(self) -> None:
+    def test_project_not_found_maps_to_td_project_not_found(self) -> None:
         from td.core.exceptions import ProjectNotFoundError
 
         exc = ProjectNotFoundError(
@@ -173,11 +305,37 @@ class TestMapCoreException:
             details={"query": "foo"},
         )
         result = map_core_exception(exc)
-        assert isinstance(result, TdError)
+        assert isinstance(result, TdProjectNotFoundError)
         assert result.code == "PROJECT_NOT_FOUND"
         assert result.message == "Project 'foo' not found"
         assert result.suggestion == "Did you mean: bar?"
         assert result.details["query"] == "foo"
+
+    def test_project_not_found_default_suggestion(self) -> None:
+        from td.core.exceptions import ProjectNotFoundError
+
+        exc = ProjectNotFoundError("Project 'x' not found")
+        result = map_core_exception(exc)
+        assert isinstance(result, TdProjectNotFoundError)
+        assert "td projects" in result.suggestion
+
+    def test_section_not_found_maps_correctly(self) -> None:
+        from td.core.exceptions import SectionNotFoundError
+
+        exc = SectionNotFoundError("Section 'x' not found")
+        result = map_core_exception(exc)
+        assert isinstance(result, TdNotFoundError)
+        assert result.code == "SECTION_NOT_FOUND"
+        assert "td sections" in result.suggestion
+
+    def test_label_not_found_maps_correctly(self) -> None:
+        from td.core.exceptions import LabelNotFoundError
+
+        exc = LabelNotFoundError("Label 'x' not found")
+        result = map_core_exception(exc)
+        assert isinstance(result, TdNotFoundError)
+        assert result.code == "LABEL_NOT_FOUND"
+        assert "td labels" in result.suggestion
 
     def test_generic_core_error(self) -> None:
         from td.core.exceptions import TdCoreError
@@ -186,3 +344,59 @@ class TestMapCoreException:
         result = map_core_exception(exc)
         assert isinstance(result, TdError)
         assert result.code == "CUSTOM"
+
+    def test_generic_core_error_has_suggestion(self) -> None:
+        from td.core.exceptions import TdCoreError
+
+        exc = TdCoreError("something broke", code="CUSTOM")
+        result = map_core_exception(exc)
+        assert result.suggestion != ""
+
+    def test_non_core_exception_has_suggestion(self) -> None:
+        exc = RuntimeError("unexpected")
+        result = map_core_exception(exc)
+        assert isinstance(result, TdApiError)
+        assert "TD_DEBUG" in result.suggestion
+
+
+class TestJsonEnvelopeConsistency:
+    """Verify that all error types produce consistent JSON envelopes."""
+
+    def _check_envelope(self, err: TdError) -> None:
+        data = json.loads(err.format_json())
+        assert data["ok"] is False
+        error = data["error"]
+        assert isinstance(error["code"], str) and len(error["code"]) > 0
+        assert isinstance(error["message"], str) and len(error["message"]) > 0
+        assert isinstance(error["suggestion"], str)
+        assert isinstance(error["details"], dict)
+
+    def test_auth_error_envelope(self) -> None:
+        self._check_envelope(TdAuthError("No token"))
+
+    def test_not_found_error_envelope(self) -> None:
+        self._check_envelope(TdNotFoundError("Not found"))
+
+    def test_validation_error_envelope(self) -> None:
+        self._check_envelope(TdValidationError("Bad input"))
+
+    def test_rate_limit_error_envelope(self) -> None:
+        self._check_envelope(TdRateLimitError("Slow down"))
+
+    def test_forbidden_error_envelope(self) -> None:
+        self._check_envelope(TdForbiddenError("No access"))
+
+    def test_timeout_error_envelope(self) -> None:
+        self._check_envelope(TdTimeoutError("Timed out"))
+
+    def test_server_error_envelope(self) -> None:
+        self._check_envelope(TdServerError("Server error"))
+
+    def test_network_error_envelope(self) -> None:
+        self._check_envelope(TdNetworkError("No connection"))
+
+    def test_cache_error_envelope(self) -> None:
+        self._check_envelope(TdCacheError("Corrupt cache"))
+
+    def test_project_not_found_error_envelope(self) -> None:
+        self._check_envelope(TdProjectNotFoundError("No project"))


### PR DESCRIPTION
## Summary
- Adds specific HTTP status handlers (408, 500, 502, 503, 504) with tailored human-readable messages and suggestions
- Adds network error handling for httpx.ConnectTimeout, ReadTimeout, ConnectError, and generic TimeoutException
- Introduces new error subclasses: TdForbiddenError, TdTimeoutError, TdServerError, TdNetworkError, TdCacheError
- Improves map_core_exception to map ProjectNotFoundError, SectionNotFoundError, LabelNotFoundError to appropriate CLI errors with default suggestions
- Ensures every error path includes an actionable suggestion field
- Adds OSError handling to cache load functions for corrupt file resilience
- Comprehensive tests for all new error paths and JSON envelope consistency

Closes #227

## Test plan
- [ ] Verify all new error subclasses produce consistent JSON envelopes (`ok`, `code`, `message`, `suggestion`, `details`)
- [ ] Verify HTTP 408/500/502/503/504 map to TdServerError/TdTimeoutError with specific messages
- [ ] Verify httpx.ConnectTimeout/ReadTimeout/ConnectError map to TdTimeoutError/TdNetworkError
- [ ] Verify map_core_exception handles ProjectNotFoundError, SectionNotFoundError, LabelNotFoundError
- [ ] Verify fallback errors include TD_DEBUG suggestion
- [ ] CI passes lint + tests with 85% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)