### PR TITLE
feat(tasks): add td completed command

### DIFF
--- a/src/td/cli/__init__.py
+++ b/src/td/cli/__init__.py
@@ -118,6 +118,7 @@ def _register_commands() -> None:
     from td.cli.tasks import (
         add,
         capture,
+        completed,
         delete,
         done,
         edit,
@@ -145,6 +146,7 @@ def _register_commands() -> None:
     cli.add_command(today)
     cli.add_command(next_task)
     cli.add_command(log)
+    cli.add_command(completed)
     cli.add_command(focus)
     cli.add_command(done)
     cli.add_command(edit)

--- a/src/td/cli/output.py
+++ b/src/td/cli/output.py
@@ -149,6 +149,17 @@ def _task_plain_row(
     return "\t".join(parts)
 
 
+def _format_completed_date(completed_at: str | None) -> str:
+    """Format a completed_at ISO timestamp into a readable date string."""
+    if not completed_at:
+        return ""
+    try:
+        dt = datetime.fromisoformat(str(completed_at))
+        return dt.strftime("%Y-%m-%d %H:%M")
+    except (ValueError, TypeError):
+        return str(completed_at)
+
+
 class OutputFormatter:
     """Central output formatter. Every command uses this."""
 
@@ -335,6 +346,64 @@ class OutputFormatter:
                 labels = ", ".join(f"@{lbl}" for lbl in task.labels) if task.labels else ""
                 row.append(labels)
             table.add_row(*row)
+
+        self._console.print(table)
+
+    # --- Completed tasks ---
+
+    def completed_list(
+        self,
+        tasks: list[Task],
+        title: str = "Completed today",
+        project_names: dict[str, str] | None = None,
+    ) -> None:
+        """Render a list of completed tasks with content, completed date, and project."""
+        if not tasks:
+            empty_msg = f"No tasks completed ({title.lower()})."
+            if title == "Completed today":
+                empty_msg = "No tasks completed today."
+            if self.mode == OutputMode.JSON:
+                self._json_out([], "completed_list")
+            elif self.mode == OutputMode.PLAIN:
+                click.echo(empty_msg)
+            else:
+                assert self._console is not None
+                self._console.print(f"[dim]{empty_msg}[/dim]")
+            return
+
+        if self.mode == OutputMode.JSON:
+            data = []
+            for t in tasks:
+                d = _task_to_dict(t, project_names)
+                d["completed_at"] = getattr(t, "completed_at", None)
+                data.append(d)
+            self._json_out(data, "completed_list")
+        elif self.mode == OutputMode.PLAIN:
+            click.echo("CONTENT\tCOMPLETED\tPROJECT")
+            for t in tasks:
+                completed_at = _format_completed_date(getattr(t, "completed_at", None))
+                project = project_names.get(t.project_id, "") if project_names else ""
+                click.echo(f"{t.content}\t{completed_at}\t{project}")
+        else:
+            self._rich_completed_table(tasks, title, project_names)
+
+    def _rich_completed_table(
+        self,
+        tasks: list[Task],
+        title: str,
+        project_names: dict[str, str] | None = None,
+    ) -> None:
+        assert self._console is not None
+
+        table = Table(title=title, show_lines=False)
+        table.add_column("Content")
+        table.add_column("Completed", style="green")
+        table.add_column("Project", style="dim")
+
+        for t in tasks:
+            completed_at = _format_completed_date(getattr(t, "completed_at", None))
+            project = project_names.get(t.project_id, "") if project_names else ""
+            table.add_row(t.content, completed_at, project)
 
         self._console.print(table)
 

--- a/src/td/cli/tasks.py
+++ b/src/td/cli/tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from datetime import datetime
 from typing import Any, cast
 
 import click
@@ -26,6 +27,7 @@ from td.core.tasks import (
     create_task,
     edit_task,
     find_task_by_content,
+    get_completed_tasks,
     list_tasks,
     quick_add,
     remove_task,
@@ -404,6 +406,106 @@ def log(ctx: click.Context, week: bool) -> None:
     ]
     pnames = get_project_name_map(api)
     fmt.task_list(completed, title=title, project_names=pnames)
+
+
+def _parse_since(since_str: str) -> datetime:
+    """Parse a --since value into a datetime.
+
+    Accepts:
+    - Absolute dates: "2026-04-01"
+    - Relative strings: "7 days", "2 weeks", "1 month"
+    """
+    from datetime import timedelta
+
+    # Try absolute date first
+    try:
+        dt = datetime.strptime(since_str, "%Y-%m-%d")
+        return dt.replace(hour=0, minute=0, second=0, microsecond=0).astimezone()
+    except ValueError:
+        pass
+
+    # Try relative: "<N> <unit>"
+    parts = since_str.strip().lower().split()
+    if len(parts) == 2:
+        try:
+            count = int(parts[0])
+        except ValueError as exc:
+            raise TdValidationError(
+                f"Cannot parse date: '{since_str}'",
+                suggestion="Use 'YYYY-MM-DD' or relative like '7 days', '2 weeks'.",
+            ) from exc
+        unit = parts[1].rstrip("s")  # normalize "days" -> "day"
+        if unit == "day":
+            delta = timedelta(days=count)
+        elif unit == "week":
+            delta = timedelta(weeks=count)
+        elif unit == "month":
+            delta = timedelta(days=count * 30)
+        else:
+            raise TdValidationError(
+                f"Unknown time unit: '{parts[1]}'",
+                suggestion="Supported units: days, weeks, months.",
+            )
+        now = datetime.now().astimezone()
+        return (now - delta).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    raise TdValidationError(
+        f"Cannot parse date: '{since_str}'",
+        suggestion="Use 'YYYY-MM-DD' or relative like '7 days', '2 weeks'.",
+    )
+
+
+@click.command()
+@click.argument("project_name", required=False, default=None)
+@click.option(
+    "-p",
+    "--project",
+    "project_flag",
+    help="Filter by project.",
+    shell_complete=_complete_projects,
+)
+@click.option(
+    "--since",
+    "since_str",
+    help="Show tasks completed since date (e.g. '2026-04-01', '7 days').",
+)
+@click.pass_context
+def completed(
+    ctx: click.Context,
+    project_name: str | None,
+    project_flag: str | None,
+    since_str: str | None,
+) -> None:
+    """Show completed tasks. Defaults to today.
+
+    \b
+    Examples:
+      td completed                    Completed today
+      td completed Work               Completed today in Work project
+      td completed --since "7 days"   Completed in last 7 days
+      td completed -p Work --since "2026-04-01"
+    """
+    api = get_client()
+    fmt = _get_formatter(ctx)
+
+    # Resolve project: positional arg or -p flag
+    project = project_name or project_flag
+    project_id = None
+    if project:
+        project_id = resolve_project(api, project).id
+
+    # Resolve date range
+    now = datetime.now().astimezone()
+    if since_str:
+        since = _parse_since(since_str)
+        title = f"Completed since {since.strftime('%Y-%m-%d')}"
+    else:
+        since = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        title = "Completed today"
+
+    tasks = get_completed_tasks(api, since=since, until=now, project_id=project_id)
+    pnames = get_project_name_map(api)
+    fmt.completed_list(tasks, title=title, project_names=pnames)
 
 
 @click.command()

--- a/src/td/core/tasks.py
+++ b/src/td/core/tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
+from datetime import datetime
 from typing import Any
 
 from todoist_api_python.api import TodoistAPI
@@ -189,3 +190,22 @@ def uncomplete_task(api: TodoistAPI, task_id: str) -> bool:
 def quick_add(api: TodoistAPI, text: str) -> Task:
     """Natural language task creation via Todoist's quick-add."""
     return api.add_task_quick(text)
+
+
+def get_completed_tasks(
+    api: TodoistAPI,
+    *,
+    since: datetime,
+    until: datetime,
+    project_id: str | None = None,
+) -> list[Task]:
+    """Fetch tasks completed within a date range.
+
+    Uses completion date (when marked done), not due date.
+    If project_id is provided, filters client-side since the API endpoint
+    doesn't support project filtering.
+    """
+    tasks = _collect(api.get_completed_tasks_by_completion_date(since=since, until=until))
+    if project_id:
+        tasks = [t for t in tasks if t.project_id == project_id]
+    return tasks

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -474,3 +474,59 @@ class TestRichOutput:
         fmt = OutputFormatter(OutputMode.RICH)
         tasks = [_make_task(content="Overdue", due="2020-01-01")]
         fmt.task_list(tasks)
+
+    def test_completed_list_renders(self) -> None:
+        fmt = OutputFormatter(OutputMode.RICH)
+        task = _make_task(content="Done task")
+        task.completed_at = "2026-04-09T14:30:00Z"
+        fmt.completed_list([task], title="Completed today")
+
+    def test_completed_list_empty_renders(self) -> None:
+        fmt = OutputFormatter(OutputMode.RICH)
+        fmt.completed_list([])
+
+
+class TestCompletedListOutput:
+    def test_completed_list_json(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.JSON)
+        task = _make_task(content="Done task", project_id="p1")
+        task.completed_at = "2026-04-09T14:30:00Z"
+        fmt.completed_list([task], project_names={"p1": "Work"})
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        data = json.loads(captured.out)
+        assert data["ok"] is True
+        assert data["type"] == "completed_list"
+        assert len(data["data"]) == 1
+        assert data["data"][0]["content"] == "Done task"
+        assert data["data"][0]["completed_at"] == "2026-04-09T14:30:00Z"
+        assert data["data"][0]["project_name"] == "Work"
+
+    def test_completed_list_plain(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        task = _make_task(content="Done task", project_id="p1")
+        task.completed_at = "2026-04-09T14:30:00Z"
+        fmt.completed_list([task], project_names={"p1": "Work"})
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        lines = captured.out.strip().split("\n")
+        assert lines[0] == "CONTENT\tCOMPLETED\tPROJECT"
+        assert "Done task" in lines[1]
+        assert "Work" in lines[1]
+
+    def test_completed_list_empty_json(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.JSON)
+        fmt.completed_list([])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        data = json.loads(captured.out)
+        assert data["ok"] is True
+        assert data["type"] == "completed_list"
+        assert data["data"] == []
+
+    def test_completed_list_empty_plain(self, capsys: object) -> None:
+        fmt = OutputFormatter(OutputMode.PLAIN)
+        fmt.completed_list([])
+
+        captured = capsys.readouterr()  # type: ignore[union-attr]
+        assert "No tasks completed today." in captured.out

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -30,6 +30,7 @@ class TestSchemaCommand:
             "capture",
             "comment",
             "comments",
+            "completed",
             "ls",
             "done",
             "edit",

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -166,6 +166,128 @@ class TestLogCommand:
         assert result.exit_code == 0
 
 
+class TestCompletedCommand:
+    @patch("td.cli.tasks.get_client")
+    def test_completed_today_default(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_completed_tasks_by_completion_date.return_value = iter(
+            [[_mock_task(content="Done task", project_id="p1")]]
+        )
+        api.get_projects.return_value = iter([[_mock_project(id="p1", name="Work")]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "completed"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["type"] == "completed_list"
+        assert len(data["data"]) == 1
+        assert data["data"][0]["content"] == "Done task"
+
+    @patch("td.cli.tasks.get_client")
+    def test_completed_since_absolute(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_completed_tasks_by_completion_date.return_value = iter(
+            [[_mock_task(content="Old task")]]
+        )
+        api.get_projects.return_value = iter([[_mock_project()]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "completed", "--since", "2026-04-01"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["type"] == "completed_list"
+
+    @patch("td.cli.tasks.get_client")
+    def test_completed_since_relative(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_completed_tasks_by_completion_date.return_value = iter(
+            [[_mock_task(content="Recent task")]]
+        )
+        api.get_projects.return_value = iter([[_mock_project()]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "completed", "--since", "7 days"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["type"] == "completed_list"
+
+    @patch("td.cli.tasks.get_client")
+    def test_completed_project_positional(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        task = _mock_task(content="Work task", project_id="p1")
+        api.get_completed_tasks_by_completion_date.return_value = iter([[task]])
+        proj = _mock_project(id="p1", name="Work")
+        api.get_projects.return_value = iter([[proj]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "completed", "Work"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["type"] == "completed_list"
+
+    @patch("td.cli.tasks.get_client")
+    def test_completed_project_flag(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        task = _mock_task(content="Work task", project_id="p1")
+        api.get_completed_tasks_by_completion_date.return_value = iter([[task]])
+        proj = _mock_project(id="p1", name="Work")
+        api.get_projects.return_value = iter([[proj]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "completed", "-p", "Work"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["type"] == "completed_list"
+
+    @patch("td.cli.tasks.get_client")
+    def test_completed_empty(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_completed_tasks_by_completion_date.return_value = iter([[]])
+        api.get_projects.return_value = iter([[_mock_project()]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "completed"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["type"] == "completed_list"
+        assert data["data"] == []
+
+    @patch("td.cli.tasks.get_client")
+    def test_completed_empty_plain(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_completed_tasks_by_completion_date.return_value = iter([[]])
+        api.get_projects.return_value = iter([[_mock_project()]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--plain", "completed"])
+
+        assert result.exit_code == 0
+        assert "No tasks completed today." in result.output
+
+    @patch("td.cli.tasks.get_client")
+    def test_completed_invalid_since(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "completed", "--since", "garbage"])
+
+        assert result.exit_code == 1
+
+
 class TestFocusCommand:
     @patch("td.cli.tasks.get_client")
     def test_focus_project(self, mock_gc: MagicMock) -> None:


### PR DESCRIPTION
## Summary

- Adds `td completed` command to view completed tasks, defaulting to today
- Supports `--since` for date ranges (absolute: `2026-04-01`, relative: `7 days`, `2 weeks`)
- Positional project arg (`td completed Work`) and `-p` flag for project scoping
- New `completed_list()` output method with Rich table, JSON envelope, and plain-text modes
- Core logic in `get_completed_tasks()` using the SDK's `get_completed_tasks_by_completion_date` endpoint with client-side project filtering

## Test plan

- [ ] `td completed` shows tasks completed today
- [ ] `td completed --since "7 days"` shows last 7 days
- [ ] `td completed Work` and `td completed -p Work` both scope to project
- [ ] `td completed --json` outputs envelope format
- [ ] `td completed --plain` outputs tab-separated format
- [ ] Empty state shows helpful message
- [ ] Invalid `--since` value shows structured error with suggestion
- [ ] CI passes: lint, tests (85% coverage), schema test updated

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)