### PR TITLE
feat(config): completions UX overhaul and PATH collision detection

### DIFF
--- a/src/td/cli/config_cmd.py
+++ b/src/td/cli/config_cmd.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
+import sys
+from pathlib import Path
 
 import click
 from rich.console import Console
@@ -12,6 +15,158 @@ from todoist_api_python.api import TodoistAPI
 from td.core.config import TdConfig, get_config_path, load_config, save_config
 
 _TODOIST_SETTINGS_URL = "https://app.todoist.com/app/settings/integrations/developer"
+
+_SUPPORTED_SHELLS = ("bash", "zsh", "fish")
+
+# Completion line templates
+_COMPLETION_LINES: dict[str, str] = {
+    "bash": 'eval "$(_TD_COMPLETE=bash_source td)"',
+    "zsh": 'eval "$(_TD_COMPLETE=zsh_source td)"',
+    "fish": "_TD_COMPLETE=fish_source td | source",
+}
+
+# Profile file paths (relative to $HOME)
+_PROFILE_FILES: dict[str, str] = {
+    "bash": ".bashrc",
+    "zsh": ".zshrc",
+    "fish": ".config/fish/config.fish",
+}
+
+
+def _detect_shell() -> str | None:
+    """Detect the current shell from $SHELL."""
+    shell_path = os.environ.get("SHELL", "")
+    for name in _SUPPORTED_SHELLS:
+        if name in shell_path:
+            return name
+    return None
+
+
+def _get_profile_path(shell: str) -> Path:
+    """Return the profile file path for a given shell."""
+    home = Path.home()
+    return home / _PROFILE_FILES[shell]
+
+
+def _is_completion_installed(shell: str) -> tuple[bool, Path]:
+    """Check if the completion line is already in the profile file.
+
+    Returns (installed, profile_path).
+    """
+    profile = _get_profile_path(shell)
+    line = _COMPLETION_LINES[shell]
+    if profile.exists():
+        content = profile.read_text()
+        return line in content, profile
+    return False, profile
+
+
+def _require_shell(shell: str | None) -> str:
+    """Resolve and validate shell, raising UsageError if unsupported."""
+    if shell is None:
+        shell = _detect_shell()
+    if shell is None:
+        supported = ", ".join(_SUPPORTED_SHELLS)
+        raise click.UsageError(
+            f"Could not detect shell from $SHELL. "
+            f"Specify one explicitly with --shell [{supported}]"
+        )
+    return shell
+
+
+def _install_completions(shell: str) -> tuple[bool, Path]:
+    """Install completion line into profile file.
+
+    Returns (was_installed, profile_path). If already present, returns (False, path).
+    """
+    profile = _get_profile_path(shell)
+    line = _COMPLETION_LINES[shell]
+
+    # Idempotent: skip if already present
+    needs_newline = False
+    if profile.exists():
+        content = profile.read_text()
+        if line in content:
+            return False, profile
+        needs_newline = bool(content) and not content.endswith("\n")
+    else:
+        # Create parent dirs for fish
+        profile.parent.mkdir(parents=True, exist_ok=True)
+
+    # Append the completion line
+    with profile.open("a") as f:
+        if needs_newline:
+            f.write("\n")
+        f.write(f"{line}\n")
+
+    return True, profile
+
+
+def _uninstall_completions(shell: str) -> tuple[bool, Path]:
+    """Remove completion line from profile file.
+
+    Returns (was_removed, profile_path). If not present, returns (False, path).
+    """
+    profile = _get_profile_path(shell)
+    line = _COMPLETION_LINES[shell]
+
+    if not profile.exists():
+        return False, profile
+
+    content = profile.read_text()
+    if line not in content:
+        return False, profile
+
+    # Remove the line (and trailing newline)
+    new_content = content.replace(f"{line}\n", "")
+    # Handle case where line is at end without trailing newline
+    new_content = new_content.replace(line, "")
+    profile.write_text(new_content)
+
+    return True, profile
+
+
+def _check_path_collision() -> str | None:
+    """Check if another 'td' binary exists on PATH that might conflict.
+
+    Returns a warning message if a collision is detected, None otherwise.
+    """
+    # Find all 'td' executables on PATH
+    td_path = shutil.which("td")
+    if td_path is None:
+        return None
+
+    # Check all PATH entries for td binaries
+    path_dirs = os.environ.get("PATH", "").split(os.pathsep)
+    td_locations: list[str] = []
+    for d in path_dirs:
+        candidate = Path(d) / "td"
+        if candidate.exists() and candidate.is_file():
+            td_locations.append(str(candidate.resolve()))
+
+    # Deduplicate
+    unique_locations = list(dict.fromkeys(td_locations))
+
+    if len(unique_locations) <= 1:
+        return None
+
+    # There are multiple td binaries
+    # The first one on PATH is what runs when user types 'td'
+    first = unique_locations[0]
+    # Try to determine which one is "ours"
+    # Our td is typically installed in the same prefix as sys.executable
+    our_prefix = str(Path(sys.executable).resolve().parent)
+    others = [loc for loc in unique_locations if not loc.startswith(our_prefix)]
+
+    if not others:
+        return None
+
+    return (
+        f'"td" is already on your PATH ({others[0]})\n'
+        "  To avoid conflicts, add an alias to your shell profile:\n"
+        '    alias todo="td"\n'
+        f"  Or ensure {first} points to this installation."
+    )
 
 
 @click.command()
@@ -79,6 +234,25 @@ def init() -> None:
         click.echo()
         click.echo("To persist it, add TD_API_TOKEN to your shell profile or .env file.")
 
+    # Offer shell completions
+    detected_shell = _detect_shell()
+    if detected_shell:
+        installed, _profile = _is_completion_installed(detected_shell)
+        if not installed:
+            click.echo()
+            enable = click.confirm("Enable shell completions?", default=True)
+            if enable:
+                was_installed, profile = _install_completions(detected_shell)
+                if was_installed:
+                    click.echo(f"Completions added to {profile}")
+                    click.echo("Restart your shell or run: source " + str(profile))
+
+    # PATH collision detection
+    collision_msg = _check_path_collision()
+    if collision_msg:
+        click.echo()
+        click.echo(f"Warning: {collision_msg}")
+
     click.echo()
     click.echo("Try `td ls` to see your tasks.")
 
@@ -104,36 +278,85 @@ def _handle_auth_error(e: Exception) -> None:
     raise SystemExit(1) from None
 
 
-_SUPPORTED_SHELLS = ("bash", "zsh", "fish")
-
-
-def _detect_shell() -> str | None:
-    """Detect the current shell from $SHELL."""
-    shell_path = os.environ.get("SHELL", "")
-    for name in _SUPPORTED_SHELLS:
-        if name in shell_path:
-            return name
-    return None
-
-
-@click.command()
-@click.argument("shell", type=click.Choice(_SUPPORTED_SHELLS), required=False)
-def completions(shell: str | None) -> None:
-    """Generate shell completion script.
+@click.group(invoke_without_command=True)
+@click.option(
+    "--shell",
+    type=click.Choice(_SUPPORTED_SHELLS),
+    default=None,
+    help="Shell to use (auto-detected from $SHELL if omitted).",
+)
+@click.pass_context
+def completions(ctx: click.Context, shell: str | None) -> None:
+    """Manage shell tab completions.
 
     \b
-    Auto-detects your shell from $SHELL, or specify one explicitly:
-      td completions         # auto-detect
-      td completions zsh     # explicit
+    Without a subcommand, shows completion status for your shell.
+    Subcommands: install, uninstall, show
     """
-    if not shell:
-        shell = _detect_shell()
-        if not shell:
-            supported = ", ".join(_SUPPORTED_SHELLS)
-            raise click.UsageError(
-                f"Could not detect shell from $SHELL. "
-                f"Specify one explicitly: td completions [{supported}]"
-            )
+    ctx.ensure_object(dict)
+    ctx.obj["shell_override"] = shell
+
+    if ctx.invoked_subcommand is not None:
+        return
+
+    # No subcommand: show status
+    resolved = shell if shell else _detect_shell()
+    if resolved is None:
+        supported = ", ".join(_SUPPORTED_SHELLS)
+        raise click.UsageError(
+            f"Could not detect shell from $SHELL. Specify one with --shell [{supported}]"
+        )
+
+    installed, profile = _is_completion_installed(resolved)
+    click.echo(f"Shell:  {resolved}")
+    if installed:
+        click.echo(f"Status: installed ({profile})")
+    else:
+        click.echo("Status: not installed")
+        click.echo()
+        click.echo("To enable tab completions, run:")
+        click.echo("  td completions install")
+        click.echo()
+        click.echo(f"This adds a single line to your {profile}. You can remove it anytime with:")
+        click.echo("  td completions uninstall")
+
+
+@completions.command()
+@click.pass_context
+def install(ctx: click.Context) -> None:
+    """Install shell completions into your profile."""
+    shell_override = ctx.obj.get("shell_override")
+    shell = _require_shell(shell_override)
+
+    was_installed, profile = _install_completions(shell)
+    if was_installed:
+        click.echo(f"Completions installed for {shell} in {profile}")
+        click.echo(f"Restart your shell or run: source {profile}")
+    else:
+        click.echo(f"Completions already installed in {profile}")
+
+
+@completions.command()
+@click.pass_context
+def uninstall(ctx: click.Context) -> None:
+    """Remove shell completions from your profile."""
+    shell_override = ctx.obj.get("shell_override")
+    shell = _require_shell(shell_override)
+
+    was_removed, profile = _uninstall_completions(shell)
+    if was_removed:
+        click.echo(f"Completions removed from {profile}")
+        click.echo(f"Restart your shell or run: source {profile}")
+    else:
+        click.echo("No completions found to remove.")
+
+
+@completions.command()
+@click.pass_context
+def show(ctx: click.Context) -> None:
+    """Output the raw completion script."""
+    shell_override = ctx.obj.get("shell_override")
+    shell = _require_shell(shell_override)
 
     var = "_TD_COMPLETE"
     if shell == "bash":

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -24,6 +25,8 @@ class TestInit:
         )
 
         monkeypatch.setattr("td.cli.config_cmd.TodoistAPI", lambda token: mock_api)
+        # Prevent completions prompt from interfering
+        monkeypatch.setattr("td.cli.config_cmd._detect_shell", lambda: None)
 
         runner = CliRunner()
         result = runner.invoke(cli, ["init"], input="test-token-123\n1\n")
@@ -84,6 +87,7 @@ class TestInit:
         )
 
         monkeypatch.setattr("td.cli.config_cmd.TodoistAPI", lambda token: mock_api)
+        monkeypatch.setattr("td.cli.config_cmd._detect_shell", lambda: None)
 
         runner = CliRunner()
         result = runner.invoke(cli, ["init"], input="secret-token-abc123\n2\n")
@@ -101,6 +105,7 @@ class TestInit:
         mock_api = MagicMock()
         mock_api.get_projects.return_value = iter([[MagicMock()]])
         monkeypatch.setattr("td.cli.config_cmd.TodoistAPI", lambda token: mock_api)
+        monkeypatch.setattr("td.cli.config_cmd._detect_shell", lambda: None)
 
         runner = CliRunner()
         result = runner.invoke(cli, ["init"], input="test-token\n1\n")
@@ -117,6 +122,7 @@ class TestInit:
         mock_api = MagicMock()
         mock_api.get_projects.return_value = iter([[MagicMock()]])
         monkeypatch.setattr("td.cli.config_cmd.TodoistAPI", lambda token: mock_api)
+        monkeypatch.setattr("td.cli.config_cmd._detect_shell", lambda: None)
 
         runner = CliRunner()
         result = runner.invoke(cli, ["init"], input="test-token\n1\n")
@@ -193,42 +199,398 @@ class TestInit:
         assert result.exit_code == 1
         assert "rate limit" in result.output
 
+    def test_init_offers_completions(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("TD_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("TD_API_TOKEN", raising=False)
 
-class TestCompletions:
-    @pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
-    def test_outputs_completion_script(self, shell: str) -> None:
+        mock_api = MagicMock()
+        mock_api.get_projects.return_value = iter([[MagicMock()]])
+        monkeypatch.setattr("td.cli.config_cmd.TodoistAPI", lambda token: mock_api)
+        monkeypatch.setattr("td.cli.config_cmd._detect_shell", lambda: "zsh")
+        monkeypatch.setattr(
+            "td.cli.config_cmd._is_completion_installed",
+            lambda shell: (False, tmp_path / ".zshrc"),
+        )
+
+        installed_calls: list[str] = []
+
+        def mock_install(shell: str) -> tuple[bool, Path]:
+            installed_calls.append(shell)
+            return True, tmp_path / ".zshrc"
+
+        monkeypatch.setattr("td.cli.config_cmd._install_completions", mock_install)
+        monkeypatch.setattr("td.cli.config_cmd._check_path_collision", lambda: None)
+
         runner = CliRunner()
-        result = runner.invoke(cli, ["completions", shell])
+        # token + choice 1 + Y for completions
+        result = runner.invoke(cli, ["init"], input="test-token\n1\nY\n")
 
         assert result.exit_code == 0
-        assert "_TD_COMPLETE" in result.output
+        assert len(installed_calls) == 1
+        assert installed_calls[0] == "zsh"
+        assert "Completions added" in result.output
 
-    def test_rejects_invalid_shell(self) -> None:
+    def test_init_skips_completions_when_declined(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("TD_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("TD_API_TOKEN", raising=False)
+
+        mock_api = MagicMock()
+        mock_api.get_projects.return_value = iter([[MagicMock()]])
+        monkeypatch.setattr("td.cli.config_cmd.TodoistAPI", lambda token: mock_api)
+        monkeypatch.setattr("td.cli.config_cmd._detect_shell", lambda: "zsh")
+        monkeypatch.setattr(
+            "td.cli.config_cmd._is_completion_installed",
+            lambda shell: (False, tmp_path / ".zshrc"),
+        )
+        monkeypatch.setattr("td.cli.config_cmd._check_path_collision", lambda: None)
+
         runner = CliRunner()
-        result = runner.invoke(cli, ["completions", "powershell"])
+        result = runner.invoke(cli, ["init"], input="test-token\n1\nn\n")
 
-        assert result.exit_code != 0
+        assert result.exit_code == 0
+        assert "Completions added" not in result.output
 
-    def test_auto_detects_zsh(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_init_skips_completions_when_already_installed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("TD_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("TD_API_TOKEN", raising=False)
+
+        mock_api = MagicMock()
+        mock_api.get_projects.return_value = iter([[MagicMock()]])
+        monkeypatch.setattr("td.cli.config_cmd.TodoistAPI", lambda token: mock_api)
+        monkeypatch.setattr("td.cli.config_cmd._detect_shell", lambda: "zsh")
+        monkeypatch.setattr(
+            "td.cli.config_cmd._is_completion_installed",
+            lambda shell: (True, tmp_path / ".zshrc"),
+        )
+        monkeypatch.setattr("td.cli.config_cmd._check_path_collision", lambda: None)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["init"], input="test-token\n1\n")
+
+        assert result.exit_code == 0
+        # Should not prompt about completions since already installed
+        assert "Enable shell completions" not in result.output
+
+
+class TestCompletionsStatus:
+    def test_status_not_installed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setenv("SHELL", "/bin/zsh")
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: tmp_path / ".zshrc")
+
         runner = CliRunner()
         result = runner.invoke(cli, ["completions"])
 
         assert result.exit_code == 0
-        assert "zsh_source" in result.output
+        assert "zsh" in result.output
+        assert "not installed" in result.output
+        assert "td completions install" in result.output
 
-    def test_auto_detects_bash(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("SHELL", "/bin/bash")
+    def test_status_installed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        profile = tmp_path / ".zshrc"
+        profile.write_text('eval "$(_TD_COMPLETE=zsh_source td)"\n')
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: profile)
+
         runner = CliRunner()
         result = runner.invoke(cli, ["completions"])
 
         assert result.exit_code == 0
-        assert "bash_source" in result.output
+        assert "zsh" in result.output
+        assert "installed" in result.output
+        assert "not installed" not in result.output
 
-    def test_auto_detect_fails_gracefully(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_status_with_shell_override(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: tmp_path / ".bashrc")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "--shell", "bash"])
+
+        assert result.exit_code == 0
+        assert "bash" in result.output
+        assert "not installed" in result.output
+
+    def test_status_unsupported_shell(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("SHELL", "/bin/csh")
+
         runner = CliRunner()
         result = runner.invoke(cli, ["completions"])
 
         assert result.exit_code != 0
         assert "Could not detect shell" in result.output
+
+
+class TestCompletionsInstall:
+    def test_install_creates_line(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        profile = tmp_path / ".zshrc"
+        profile.write_text("# existing config\n")
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: profile)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "install"])
+
+        assert result.exit_code == 0
+        assert "installed" in result.output.lower()
+        content = profile.read_text()
+        assert 'eval "$(_TD_COMPLETE=zsh_source td)"' in content
+
+    def test_install_idempotent(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        profile = tmp_path / ".zshrc"
+        profile.write_text('eval "$(_TD_COMPLETE=zsh_source td)"\n')
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: profile)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "install"])
+
+        assert result.exit_code == 0
+        assert "already installed" in result.output.lower()
+        # Verify line not duplicated
+        content = profile.read_text()
+        assert content.count("_TD_COMPLETE") == 1
+
+    def test_install_bash(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("SHELL", "/bin/bash")
+        profile = tmp_path / ".bashrc"
+        profile.write_text("")
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: profile)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "install"])
+
+        assert result.exit_code == 0
+        content = profile.read_text()
+        assert 'eval "$(_TD_COMPLETE=bash_source td)"' in content
+
+    def test_install_fish(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("SHELL", "/usr/bin/fish")
+        fish_dir = tmp_path / ".config" / "fish"
+        fish_dir.mkdir(parents=True)
+        profile = fish_dir / "config.fish"
+        profile.write_text("")
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: profile)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "install"])
+
+        assert result.exit_code == 0
+        content = profile.read_text()
+        assert "_TD_COMPLETE=fish_source td | source" in content
+
+    def test_install_creates_profile_if_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        profile = tmp_path / ".zshrc"
+        # Don't create the file
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: profile)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "install"])
+
+        assert result.exit_code == 0
+        assert profile.exists()
+        assert "_TD_COMPLETE" in profile.read_text()
+
+    def test_install_unsupported_shell(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SHELL", "/bin/csh")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "install"])
+
+        assert result.exit_code != 0
+        assert "Could not detect shell" in result.output
+
+
+class TestCompletionsUninstall:
+    def test_uninstall_removes_line(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        profile = tmp_path / ".zshrc"
+        profile.write_text('# my config\neval "$(_TD_COMPLETE=zsh_source td)"\n# other stuff\n')
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: profile)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "uninstall"])
+
+        assert result.exit_code == 0
+        assert "removed" in result.output.lower()
+        content = profile.read_text()
+        assert "_TD_COMPLETE" not in content
+        assert "my config" in content
+        assert "other stuff" in content
+
+    def test_uninstall_noop_when_not_installed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        profile = tmp_path / ".zshrc"
+        profile.write_text("# just comments\n")
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: profile)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "uninstall"])
+
+        assert result.exit_code == 0
+        assert "no completions found" in result.output.lower()
+
+    def test_uninstall_noop_when_no_profile(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        profile = tmp_path / ".zshrc"
+        monkeypatch.setattr("td.cli.config_cmd._get_profile_path", lambda s: profile)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "uninstall"])
+
+        assert result.exit_code == 0
+        assert "no completions found" in result.output.lower()
+
+
+class TestCompletionsShow:
+    def test_show_zsh(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "show"])
+
+        assert result.exit_code == 0
+        assert "zsh_source" in result.output
+        assert "_TD_COMPLETE" in result.output
+
+    def test_show_bash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SHELL", "/bin/bash")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "show"])
+
+        assert result.exit_code == 0
+        assert "bash_source" in result.output
+
+    def test_show_fish(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SHELL", "/usr/bin/fish")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "show"])
+
+        assert result.exit_code == 0
+        assert "fish_source" in result.output
+
+    def test_show_with_shell_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["completions", "--shell", "bash", "show"])
+
+        assert result.exit_code == 0
+        assert "bash_source" in result.output
+
+
+class TestPathCollision:
+    def test_no_collision(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When there is only one td on PATH, no warning."""
+        from td.cli.config_cmd import _check_path_collision
+
+        monkeypatch.setattr("td.cli.config_cmd.shutil.which", lambda name: "/usr/local/bin/td")
+        monkeypatch.setenv("PATH", "/usr/local/bin")
+
+        # Mock Path.exists and is_file for the single candidate
+        original_exists = Path.exists
+        original_is_file = Path.is_file
+
+        def mock_exists(self: Path) -> bool:
+            if str(self) == "/usr/local/bin/td":
+                return True
+            return original_exists(self)
+
+        def mock_is_file(self: Path) -> bool:
+            if str(self) == "/usr/local/bin/td":
+                return True
+            return original_is_file(self)
+
+        monkeypatch.setattr(Path, "exists", mock_exists)
+        monkeypatch.setattr(Path, "is_file", mock_is_file)
+
+        result = _check_path_collision()
+        assert result is None
+
+    def test_collision_detected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When multiple td binaries exist, a warning is returned."""
+        from td.cli.config_cmd import _check_path_collision
+
+        monkeypatch.setattr("td.cli.config_cmd.shutil.which", lambda name: "/usr/local/bin/td")
+        monkeypatch.setenv("PATH", "/usr/local/bin:/home/user/.local/bin")
+
+        # Both directories have a td binary
+        original_exists = Path.exists
+        original_is_file = Path.is_file
+
+        td_paths = {"/usr/local/bin/td", "/home/user/.local/bin/td"}
+
+        def mock_exists(self: Path) -> bool:
+            if str(self) in td_paths:
+                return True
+            return original_exists(self)
+
+        def mock_is_file(self: Path) -> bool:
+            if str(self) in td_paths:
+                return True
+            return original_is_file(self)
+
+        def mock_resolve(self: Path) -> Path:
+            # Return the path as-is for our test paths
+            if str(self) in td_paths:
+                return self
+            return Path(os.path.realpath(str(self)))
+
+        monkeypatch.setattr(Path, "exists", mock_exists)
+        monkeypatch.setattr(Path, "is_file", mock_is_file)
+        monkeypatch.setattr(Path, "resolve", mock_resolve)
+
+        # sys.executable is in /home/user/.local/bin
+        monkeypatch.setattr("td.cli.config_cmd.sys.executable", "/home/user/.local/bin/python")
+
+        result = _check_path_collision()
+        assert result is not None
+        assert "already on your PATH" in result
+        assert "alias" in result
+
+    def test_collision_nonblocking_in_init(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """PATH collision warning does not prevent init from completing."""
+        monkeypatch.setenv("TD_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("TD_API_TOKEN", raising=False)
+
+        mock_api = MagicMock()
+        mock_api.get_projects.return_value = iter([[MagicMock()]])
+        monkeypatch.setattr("td.cli.config_cmd.TodoistAPI", lambda token: mock_api)
+        monkeypatch.setattr("td.cli.config_cmd._detect_shell", lambda: None)
+        monkeypatch.setattr(
+            "td.cli.config_cmd._check_path_collision",
+            lambda: '"td" is already on your PATH (/usr/local/bin/td)',
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["init"], input="test-token\n1\n")
+
+        assert result.exit_code == 0
+        assert "already on your PATH" in result.output
+        assert "Try `td ls`" in result.output  # init completed successfully
+
+    def test_no_td_on_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When td is not found on PATH at all."""
+        from td.cli.config_cmd import _check_path_collision
+
+        monkeypatch.setattr("td.cli.config_cmd.shutil.which", lambda name: None)
+
+        result = _check_path_collision()
+        assert result is None


### PR DESCRIPTION
## Summary

- **Completions overhaul (#229):** Convert `td completions` from a simple command to a Click group with `install`, `uninstall`, and `show` subcommands. No-args shows shell detection status and helper text. Install/uninstall are idempotent and modify the correct shell profile file (~/.zshrc, ~/.bashrc, ~/.config/fish/config.fish). `td init` now offers to install completions after auth setup.
- **PATH collision detection (#208):** During `td init`, detect if another `td` binary exists on PATH and show a non-blocking warning with alias suggestion. Detection only, does not prevent init from completing.
- Shared `--shell` option on the completions group propagates to all subcommands.

Closes #229, closes #208

## Test plan

- [ ] `td completions` shows status (installed vs not installed) for bash, zsh, fish
- [ ] `td completions install` creates the completion line, idempotent (doesn't double-add)
- [ ] `td completions uninstall` removes the line, no-op when not installed
- [ ] `td completions show` outputs raw script (moved from old behavior)
- [ ] `td completions --shell bash show` overrides auto-detection
- [ ] Unsupported shell gets helpful error
- [ ] `td init` prompts for completions after auth, skips if already installed
- [ ] PATH collision warning appears during init when multiple td binaries exist
- [ ] PATH collision is non-blocking (init completes successfully)
- [ ] Schema test still passes (completions remains a top-level command)
- [ ] `make check` passes (lint + tests + 85% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)