### PR TITLE
fix(tasks): error early when text ref has no fuzzy match

### DIFF
--- a/src/td/cli/tasks.py
+++ b/src/td/cli/tasks.py
@@ -69,7 +69,6 @@ def _resolve_task(ref: str, api: Any = None) -> str:
             task_id: str = matches[choice - 1].id
             return task_id
         if len(matches) > 1:
-            # Non-interactive: return error-like info
             from td.cli.errors import TdValidationError
 
             task_list = ", ".join(f"'{t.content}'" for t in matches[:5])
@@ -77,8 +76,15 @@ def _resolve_task(ref: str, api: Any = None) -> str:
                 f"Multiple tasks match '{ref}': {task_list}",
                 suggestion="Be more specific or use a task ID.",
             )
+        # No matches — ref looks like text but nothing matched
+        from td.cli.errors import TdNotFoundError
 
-    # Step 3: pass through as task ID
+        raise TdNotFoundError(
+            f"Task '{ref}' not found.",
+            suggestion="Use a row number from `td ls`, a task name, or a task ID.",
+        )
+
+    # Step 3: pass through as task ID (digits or short strings)
     return ref
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -284,13 +284,40 @@ class TestCliCommands:
         """Multi-word text is content match, not batch."""
         api = MagicMock()
         mock_gc.return_value = api
+        match = _mock_task(id="t1", content="buy milk")
+        api.get_tasks.return_value = iter([[match]])
 
         runner = CliRunner()
         result = runner.invoke(cli, ["--json", "done", "buy", "milk"])
 
         assert result.exit_code == 0
-        # Should have joined into "buy milk" and treated as single ref
-        api.get_task.assert_called_once()
+        api.complete_task.assert_called_once()
+
+    @patch("td.cli.tasks.get_client")
+    def test_done_unresolvable_text_ref_errors_early(self, mock_gc: MagicMock) -> None:
+        """Text ref with no fuzzy match should error, not hit the API."""
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_tasks.return_value = iter([[]])  # no matches
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "done", "ljasdf"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+        api.complete_task.assert_not_called()
+
+    @patch("td.cli.tasks.get_client")
+    def test_done_short_ref_passes_through(self, mock_gc: MagicMock) -> None:
+        """Short refs (<=2 chars) pass through as task IDs — no fuzzy match."""
+        api = MagicMock()
+        mock_gc.return_value = api
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "done", "t1"])
+
+        assert result.exit_code == 0
+        api.complete_task.assert_called_once()
 
     @patch("td.cli.tasks.get_client")
     def test_delete_with_yes(self, mock_gc: MagicMock) -> None:


### PR DESCRIPTION
## Summary
- `_resolve_task()` now raises `TdNotFoundError` when a text ref fails fuzzy matching
- Users see `Task "ljasdf" not found` with suggestion instead of raw `400 Bad Request`
- Short refs (<=2 chars) and digits still pass through as potential task IDs
- Applies to all commands using `_resolve_task()`: done, edit, delete, show, move

## Test plan
- [x] 444 tests pass, 90.83% coverage
- [x] Text ref with no match → TdNotFoundError
- [x] Short ref passes through
- [x] Multi-word content match still works when task exists

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)