### PR TITLE
ci: add project automation workflow for Status transitions

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -29,11 +29,37 @@ env:
   STATUS_DONE: 4652251c
 
 jobs:
+  # Gate all other jobs behind the presence of PROJECT_TOKEN. When the
+  # secret is not set, every automation job is skipped cleanly (no
+  # failed checks on PRs). Craig enables the automation by creating
+  # the PROJECT_TOKEN secret; no code change needed.
+  check-token:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Check for PROJECT_TOKEN
+        id: check
+        env:
+          TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "PROJECT_TOKEN not configured. Automation jobs will skip."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "PROJECT_TOKEN is configured. Automation jobs will run."
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # Auto-add every newly opened issue to the project. Default Status is
   # Backlog (handled by the board's field default). No PRs are auto-added;
   # PRs drive issue Status transitions via the other jobs below.
   auto-add-issue:
-    if: github.event_name == 'issues' && github.event.action == 'opened'
+    needs: check-token
+    if: >-
+      needs.check-token.outputs.enabled == 'true' &&
+      github.event_name == 'issues' &&
+      github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v1
@@ -45,7 +71,11 @@ jobs:
   # When an issue is reopened, move it back to Backlog so it re-enters
   # the normal triage flow.
   issue-status-update:
-    if: github.event_name == 'issues' && (github.event.action == 'closed' || github.event.action == 'reopened')
+    needs: check-token
+    if: >-
+      needs.check-token.outputs.enabled == 'true' &&
+      github.event_name == 'issues' &&
+      (github.event.action == 'closed' || github.event.action == 'reopened')
     runs-on: ubuntu-latest
     steps:
       - name: Resolve target status
@@ -105,7 +135,11 @@ jobs:
   # by GitHub's native behavior (merge closes linked issues) plus the
   # issue-status-update job above.
   pr-opened-in-flight:
-    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    needs: check-token
+    if: >-
+      needs.check-token.outputs.enabled == 'true' &&
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'opened' || github.event.action == 'reopened')
     runs-on: ubuntu-latest
     steps:
       - name: Move linked issues to In flight

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,172 @@
+name: Project Automation
+
+# Keeps the GitHub Project (td — AI-Native Todoist CLI) in sync with
+# issue and PR state without manual board updates. See CONTRIBUTING.md
+# "Branch → PR → Merge" section for the codified rules this workflow
+# implements.
+#
+# Requires a repository secret named PROJECT_TOKEN: a Personal Access
+# Token with `project` and `repo` scopes. The default GITHUB_TOKEN
+# cannot write to Projects v2 on user-owned projects.
+
+on:
+  issues:
+    types: [opened, closed, reopened]
+  pull_request:
+    types: [opened, reopened, closed]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+env:
+  PROJECT_URL: https://github.com/users/craigmccaskill/projects/1
+  PROJECT_ID: PVT_kwHOAAGp384BSn7s
+  STATUS_FIELD_ID: PVTSSF_lAHOAAGp384BSn7szhAGnog
+  STATUS_BACKLOG: ca806499
+  STATUS_IN_FLIGHT: cfabb01d
+  STATUS_DONE: 4652251c
+
+jobs:
+  # Auto-add every newly opened issue to the project. Default Status is
+  # Backlog (handled by the board's field default). No PRs are auto-added;
+  # PRs drive issue Status transitions via the other jobs below.
+  auto-add-issue:
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: ${{ env.PROJECT_URL }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+
+  # When an issue is closed, move its project item to Done.
+  # When an issue is reopened, move it back to Backlog so it re-enters
+  # the normal triage flow.
+  issue-status-update:
+    if: github.event_name == 'issues' && (github.event.action == 'closed' || github.event.action == 'reopened')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve target status
+        id: target
+        run: |
+          if [ "${{ github.event.action }}" = "closed" ]; then
+            echo "option_id=${STATUS_DONE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "option_id=${STATUS_BACKLOG}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update issue Status
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+          TARGET_OPTION_ID: ${{ steps.target.outputs.option_id }}
+        run: |
+          set -euo pipefail
+
+          ITEM_ID=$(gh api graphql \
+            -f query='query($id: ID!) {
+              node(id: $id) {
+                ... on Issue {
+                  projectItems(first: 10) {
+                    nodes { id project { id } }
+                  }
+                }
+              }
+            }' \
+            -f id="$ISSUE_NODE_ID" \
+            --jq ".data.node.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "Issue not in project, skipping"
+            exit 0
+          fi
+
+          gh api graphql \
+            -f query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $optionId }
+              }) {
+                projectV2Item { id }
+              }
+            }' \
+            -f projectId="$PROJECT_ID" \
+            -f itemId="$ITEM_ID" \
+            -f fieldId="$STATUS_FIELD_ID" \
+            -f optionId="$TARGET_OPTION_ID"
+
+  # When a PR is opened (or reopened), find the issues it will close
+  # (via "Closes #N" / "Fixes #N" / "Resolves #N" keywords) and move
+  # them to In flight. The PR merge → issue Done transition is handled
+  # by GitHub's native behavior (merge closes linked issues) plus the
+  # issue-status-update job above.
+  pr-opened-in-flight:
+    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move linked issues to In flight
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          set -euo pipefail
+
+          LINKED_ISSUES=$(gh api graphql \
+            -f query='query($id: ID!) {
+              node(id: $id) {
+                ... on PullRequest {
+                  closingIssuesReferences(first: 10) {
+                    nodes { id number }
+                  }
+                }
+              }
+            }' \
+            -f id="$PR_NODE_ID" \
+            --jq '.data.node.closingIssuesReferences.nodes[].id')
+
+          if [ -z "$LINKED_ISSUES" ]; then
+            echo "PR does not close any issues, skipping"
+            exit 0
+          fi
+
+          for ISSUE_NODE_ID in $LINKED_ISSUES; do
+            ITEM_ID=$(gh api graphql \
+              -f query='query($id: ID!) {
+                node(id: $id) {
+                  ... on Issue {
+                    projectItems(first: 10) {
+                      nodes { id project { id } }
+                    }
+                  }
+                }
+              }' \
+              -f id="$ISSUE_NODE_ID" \
+              --jq ".data.node.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
+
+            if [ -z "$ITEM_ID" ]; then
+              echo "Linked issue $ISSUE_NODE_ID not in project, skipping"
+              continue
+            fi
+
+            gh api graphql \
+              -f query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $optionId }
+                }) {
+                  projectV2Item { id }
+                }
+              }' \
+              -f projectId="$PROJECT_ID" \
+              -f itemId="$ITEM_ID" \
+              -f fieldId="$STATUS_FIELD_ID" \
+              -f optionId="$STATUS_IN_FLIGHT"
+
+            echo "Moved linked issue to In flight: $ISSUE_NODE_ID"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **Project automation workflow** — `.github/workflows/project-automation.yml` implements the `Status` transitions that `CONTRIBUTING.md`'s Branch → PR → Merge section codified. Behavior:
+  - New issues are auto-added to the GitHub Project with default `Status = Backlog`
+  - PR opened with `Closes #N` → linked issues move to `Status = In flight`
+  - Issue closed (directly or via merged PR) → `Status = Done`
+  - Issue reopened → `Status = Backlog`
+
+  Requires a repo secret `PROJECT_TOKEN` (a Personal Access Token with `project` and `repo` scopes) because the default `GITHUB_TOKEN` cannot write to Projects v2 on user-owned projects.
+
 - **Project board conventions codified and board restructured** — field definitions and dependency tracking now documented in `CONTRIBUTING.md`, with the GitHub Project updated to match.
   - **New `Tier` field** added to the project with five values: `Needs triage` (default), `Trivial`, `Standard`, `Needs ADR`, `Exploratory`. Captures the pre-work ritual each issue needs.
   - **`Status` restructured.** Added `Ready`, `In flight`, and `Blocked`. Removed dead `Sprint` and `In Progress` options.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/project-automation.yml` to keep the GitHub Project (`td — AI-Native Todoist CLI`) in sync with issue and PR state without manual board updates. Implements the Merge → Done and PR-opened → In flight rules codified in `CONTRIBUTING.md`'s Branch → PR → Merge section.

## Four triggers

| Event | Action |
|---|---|
| Issue opened | Auto-add to project (default `Status: Backlog`) |
| PR opened or reopened with `Closes #N` | Linked issues move to `Status: In flight` |
| Issue closed (directly or via merged PR) | Issue moves to `Status: Done` |
| Issue reopened | Issue moves to `Status: Backlog` |

The PR-merged → issue-Done case is handled automatically: merging a PR closes its linked issues, which fires the `issues.closed` event, which triggers the Done transition. No duplicate handler needed.

## Implementation notes

- **Linked issues are discovered via GraphQL's `closingIssuesReferences` field**, so the workflow handles any PR that uses `Closes`/`Fixes`/`Resolves` keywords without parsing the body manually
- **Status option IDs are hardcoded** (`ca806499`, `cfabb01d`, `4652251c`) from the board restructure that landed in #252. If the Status field is restructured again, this workflow will need an update
- **Graceful fallthrough**: if an issue or PR isn't in the project (or is in a different project), the job exits cleanly without error

## Required secret: `PROJECT_TOKEN`

The workflow uses a repository secret named `PROJECT_TOKEN`, which must be a Personal Access Token with `project` and `repo` scopes. The default `GITHUB_TOKEN` can't write to Projects v2 on user-owned projects, which is why this extra setup is required.

**To set it up:**
1. Create a classic PAT at https://github.com/settings/tokens with `project` and `repo` scopes (or a fine-grained token with Project write permission)
2. Add it as a repository secret at `https://github.com/craigmccaskill/todoist-cli/settings/secrets/actions` with the name `PROJECT_TOKEN`
3. The workflow will start firing on the next issue/PR event

Until the secret is set, the auth steps will fail silently and the board will stay manually managed (which is the current state anyway, so no regression).

## Test plan

- [x] `make check` passes (lint/tests unaffected, this is a CI file change)
- [x] YAML parses with `python3 -c "import yaml; yaml.safe_load(...)"`
- [ ] After merge + secret setup: open a test issue, verify it auto-adds with `Status: Backlog`
- [ ] After merge + secret setup: open a draft PR with `Closes #<test-issue>`, verify linked issue moves to `In flight`
- [ ] After merge + secret setup: merge the test PR, verify linked issue moves to `Done`
- [ ] After merge + secret setup: reopen the test issue, verify it moves back to `Backlog`

## Limitations and follow-ups

- If `Status` field option IDs change (e.g., another restructure), the hardcoded IDs in this workflow break silently. Consider moving them to repo variables if the board schema is expected to change
- The workflow doesn't handle `Blocked` transitions. `Blocked` is intentionally manual (only a human knows when something is externally blocked)
- PR-closed-unmerged is not handled. If you close a PR without merging, the linked issues stay `In flight` until you manually move them back. Could be added if it becomes annoying
- Size, Tier, and Priority are never touched by this workflow. Those are triage fields, not status fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)