### PR TITLE
docs: document PR-linked In flight transition via native Projects v2 workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **`Priority` gains explicit definitions** (`P0` through `P3`) in `CONTRIBUTING.md` without any renaming or retagging.
   - **Triage decision framework** captured in ADR-0010. Checklist-style rubric walked for every issue leaving `Needs triage`. Classifies `Tier`, `Size`, `Priority` with worked examples and edge cases. No automation in v1 (rubric discipline only).
   - **Dependency tracking convention documented** (captured in ADR-0011). Hierarchical via GitHub task lists, cross-cutting via `Blocks:` / `Blocked by:` keywords in the issue body.
-  - **Merge → Done codified.** Merging a PR now automatically moves the linked issue's `Status` to `Done` via GitHub Projects automation. Rule documented in the Branch → PR → Merge section of `CONTRIBUTING.md`.
+  - **Board transitions automated via native Projects v2 workflows.** Merging a PR moves the linked issue's `Status` to `Done`; opening a PR with `Closes #N` moves the linked issue to `In flight`. Both run on GitHub's built-in Projects v2 workflows (`Pull request merged` and `Pull request linked to issue`). No PAT, GitHub App, or repo secret required. Rules documented in the Branch → PR → Merge section of `CONTRIBUTING.md`.
 
 - **Architecture Decision Records** — design decisions now have a durable home in `docs/decisions/` (#224). Eight retroactive ADRs capture decisions already baked into the code: design principle (#230), JSON output envelope, priority mapping, task reference resolution order, `core/`/`cli/` boundary, schema as AI contract, cache TTLs, and Click-over-Typer.
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,10 +256,11 @@ why in the PR.
 6. Squash merge to main
 
 Merging a PR automatically moves the linked issue's `Status` to
-`Done` via GitHub Projects automation. No manual board update
-required. Opening a PR similarly moves the linked issue to
-`In flight` so the board reflects in-flight work without manual
-touches.
+`Done`, and opening a PR that references an issue (via `Closes #N`
+or a similar keyword) moves the linked issue to `In flight`. Both
+transitions run on GitHub Projects v2 built-in workflows (the
+*Pull request merged* and *Pull request linked to issue* rules).
+No manual board updates required, no PAT or GitHub App needed.
 
 Feature branches merge directly to main. No long-lived release branches.
 Keep PRs focused — one issue per PR when possible.


### PR DESCRIPTION
## Summary

Corrects the `CONTRIBUTING.md` Branch → PR → Merge section to accurately describe how board transitions actually happen, and updates the matching CHANGELOG entry.

## What changed

**`CONTRIBUTING.md`** — the Branch → PR → Merge section previously claimed both that merging a PR moves a linked issue to Done AND that opening a PR moves it to In flight, without specifying the mechanism. After today's automation discovery, we now know:

- Both transitions are handled by **GitHub Projects v2 built-in workflows** (tokenless, configured in the project's Workflows UI)
- Specifically: the *Pull request merged* workflow (already enabled) and the *Pull request linked to issue* workflow (now enabled)
- No PAT, no GitHub App, no repo secret required for either

The new text names the actual workflows and clarifies that no auth setup is needed.

**`CHANGELOG.md`** — the existing `[Unreleased] > Internal` entry for *Merge → Done codified* is updated to reflect the broader reality: both Merge→Done AND PR-linked→In flight are now documented, and the mechanism (native workflows rather than GitHub Actions with tokens) is stated explicitly.

## Why

During today's work we went down a path of building a `.github/workflows/project-automation.yml` (PR #254) that duplicated what Projects v2 already does natively. Discovery resolved the "PR opened → In flight" gap via the *Pull request linked to issue* built-in workflow, which we had originally missed. Closing the documentation loop so the written process matches reality.

## Test plan

- [x] `make check` passes (474 tests, 90.38% coverage)
- [x] `mkdocs build --strict` passes
- [x] `grep "Pull request linked to issue" CONTRIBUTING.md` matches the new text

Closes #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)