### PR TITLE
docs(workflow): plan-mode default, research-before-implement, PR template ADR check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,3 +20,4 @@
 - [ ] CHANGELOG.md updated under `[Unreleased]` (Added / Changed / Fixed / Internal)
 - [ ] Bug fixes include a regression test
 - [ ] Help text updated for new/changed commands
+- [ ] This change conforms to the design principle (ADR-0001), or a new/superseding ADR is linked explaining the divergence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **Plan mode default, research-before-implement pattern, and ADR review checklist.** Three complementary safeguards against the #250 class of failure, adding the last three decisions from the workflow improvement plan:
+  - **Plan mode is now the default for `feat(tasks|output|cli)` work.** `CLAUDE.md`'s "Adding a New Command or Changing Output Shape" subsection instructs Claude Code to enter plan mode, explore, write a plan, and get approval before touching code for anything in those scopes. Bug fixes, docs, CI, and no-observable-behavior refactors are explicitly out of scope to avoid a default tax.
+  - **Research-before-implement pattern for delegated work.** When delegating via the Agent tool for changes that add a command, modify output, or touch an architectural invariant, spawn a Plan agent first. The Plan agent reads applicable ADRs (especially ADR-0001), inspects existing patterns, and proposes an approach with open questions. Implementation agent only runs after the research is reviewed. A full Plan agent prompt template lives in `CLAUDE.md`.
+  - **PR template design-principle checklist item.** `.github/pull_request_template.md` gains one checklist line asking whether the change conforms to ADR-0001 (or links a new/superseding ADR). Review-time safety net, self-enforced, cheap.
+
 - **Project board conventions codified and board restructured** — field definitions and dependency tracking now documented in `CONTRIBUTING.md`, with the GitHub Project updated to match.
   - **New `Tier` field** added to the project with five values: `Needs triage` (default), `Trivial`, `Standard`, `Needs ADR`, `Exploratory`. Captures the pre-work ritual each issue needs.
   - **`Status` restructured.** Added `Ready`, `In flight`, and `Blocked`. Removed dead `Sprint` and `In Progress` options.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,55 @@ For full rationale, read
 For other ADRs that may apply, check
 [docs/decisions/README.md](docs/decisions/README.md).
 
+### Default to plan mode for feature work
+
+Before writing any code for changes in the `feat(tasks|output|cli)`
+conventional-commit scopes, enter plan mode. Explore the relevant
+code (read-only), form a concrete implementation plan, and exit plan
+mode only once the plan is written and reviewed. Do not skip planning
+because the task *"looks simple"*. These scopes are where design
+decisions live, and the cost of shipping a wrong command design is a
+retroactive redesign under the ADR process.
+
+Out of scope: `fix(*)`, `docs`, `ci`, `chore`, and refactors that do
+not change observable behavior. Plan mode for those is optional and
+should not become a default tax.
+
+### Research-before-implement for delegated work
+
+When delegating implementation work to a background agent via the
+Agent tool for changes that add a new command, modify output shape,
+or touch an architectural invariant, spawn a **Plan agent first** to
+do research. Review the Plan agent's output before spawning the
+implementation agent.
+
+**Plan agent prompt template:**
+
+    Research task for #<issue>. Do NOT write code.
+
+    1. Read docs/decisions/README.md and identify ADRs that apply
+       to this work
+    2. Read the relevant ADRs in full (especially ADR-0001)
+    3. Read existing commands in the same area
+       (e.g. src/td/cli/tasks.py) to understand current patterns
+
+    Output a proposal with:
+
+    - Which ADRs apply and what they constrain
+    - Existing patterns to reuse (with file paths)
+    - Two or three alternative approaches with tradeoffs
+    - Recommended approach with rationale
+    - Open questions that need user decisions before implementation
+
+    Keep the output under 500 words.
+
+Only after reviewing the research output and resolving any open
+questions should you spawn the implementation agent, passing the
+approved approach and a reference to the research findings. This is
+the pattern that catches the #250 class of failure: a Plan agent
+that reads ADR-0001 before any implementation exists will flag
+design-principle violations before code is written.
+
 ### Mechanical checklist
 
 1. Business logic in `td/core/<module>.py`


### PR DESCRIPTION
## Summary

Adds the three remaining decisions from the workflow improvement plan as three complementary safeguards against the #250 class of failure (shipping design-affecting changes without applying the design principle).

- **Decision 4.** `CLAUDE.md` instructs Claude Code to enter **plan mode** before writing code for `feat(tasks|output|cli)` work.
- **Decision 5.** `CLAUDE.md` gains a **research-before-implement** pattern for delegated work, with a Plan agent prompt template.
- **Decision 6.** `.github/pull_request_template.md` gets a **design-principle checklist** item.

## Why three separate safeguards

They target three different modes where design decisions happen:

| Safeguard | Mode it protects | Failure it catches |
|---|---|---|
| Plan mode default | In-session feature work | Skipping the design pause on `feat(tasks\|output\|cli)` scopes |
| Research-before-implement | Delegated feature work | Agents following existing patterns without questioning them (the original `#250` pattern) |
| PR template checklist | Review time | Last-chance self-check before merging a design-affecting PR |

Each is cheap on its own. Defense-in-depth at every point where a design decision can get made or missed.

## What changes in `CLAUDE.md`

Two new H3 subsections inside the existing `## Adding a New Command or Changing Output Shape` section (created in the foundation PR). Both sit between the design-principle summary and the `### Mechanical checklist` so they're read before the mechanical steps:

- `### Default to plan mode for feature work` — Decision 4 content with explicit in-scope and out-of-scope conventional-commit types
- `### Research-before-implement for delegated work` — Decision 5 content with a full Plan agent prompt template

No changes elsewhere in `CLAUDE.md`.

## What changes in `.github/pull_request_template.md`

One new checklist line under the existing `## Checklist` section:

\`\`\`diff
 - [ ] `make check` passes (lint + tests)
 - [ ] CHANGELOG.md updated under `[Unreleased]` (Added / Changed / Fixed / Internal)
 - [ ] Bug fixes include a regression test
 - [ ] Help text updated for new/changed commands
+- [ ] This change conforms to the design principle (ADR-0001), or a new/superseding ADR is linked explaining the divergence
\`\`\`

## Test plan

- [x] `make check` passes (474 tests, 90.38% coverage)
- [x] \`mkdocs build --strict\` passes
- [x] \`CLAUDE.md\` renders the new subsections correctly
- [x] The PR template diff on this very PR shows the new checklist item
- [x] Cross-references to ADR-0001 resolve correctly

## Context

This is the third and final PR in the workflow improvement plan (#224 foundation, #252 board conventions, #253 triage framework, this one is the add-ons PR). The `#250` case study is the only remaining decision; it's a much larger piece of work and will land separately when we tackle the CRUD verb grammar redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)