### PR TITLE
feat(cli): reshape CRUD commands into entity groups (ADR-0009)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,12 +35,21 @@ Set `TD_API_TOKEN` env var (preferred for agents), or run `td init` interactivel
 - `td delete <ref> --yes` — delete task (same ref formats, `--yes` to skip confirmation)
 - `td comment <ref> <text>` — add a comment to a task
 - `td comments <ref>` — list comments on a task
+- `td comment edit <id> <text>` — update a comment
+- `td comment delete <id> -y` — delete a comment
 - `td projects` — list all projects
-- `td project-add <name>` — create a project (`--parent`, `--favorite`)
+- `td project add <name>` — create a project (`--parent`, `--favorite`)
+- `td project edit <ref> --name <new>` — rename or recolor a project
+- `td project delete <ref> -y` — delete a project
+- `td project archive <ref>` / `td project unarchive <ref>`
 - `td sections -p <project>` — list sections in a project
-- `td section-add <name> -p <project>` — create a section in a project
+- `td section add <name> -p <project>` — create a section in a project
+- `td section edit <ref> --name <new>` — rename a section
+- `td section delete <ref> -y` — delete a section
 - `td labels` — list all labels
-- `td label-add <name>` — create a label
+- `td label add <name>` — create a label
+- `td label edit <ref> --name <new>` — rename or recolor a label
+- `td label delete <ref> -y` — delete a label
 - `td review` — interactive TUI inbox review. `-p` for a project, `-f` for a filter. Requires `[interactive]` extra
 - `td rate-limit` — show API rate limit status from cached response headers (no API call)
 - `td schema` — full capability manifest as JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CRUD commands reshaped into entity groups** (#250, [ADR-0009](docs/decisions/0009-crud-verb-grammar.md)). The 13 hyphenated CRUD commands now live under entity groups that match how humans (and `gh`, `docker`, `kubectl`) already talk about their work.
+  ```bash
+  # Before (v0.12.x)              # After (v0.13.0+)
+  td project-add Work             td project add Work
+  td project-edit Work --name W2  td project edit Work --name W2
+  td section-add Backlog -p Blog  td section add Backlog -p Blog
+  td label-add urgent             td label add urgent
+  td comment-edit abc123 "text"   td comment edit abc123 "text"
+  ```
+  All four entity groups (`project`, `section`, `label`, `comment`) expose the same verb vocabulary: `list`, `add`, `edit`, `delete` — plus `archive`/`unarchive` on `project`. The group help (`td project --help`) lists the verbs.
+
+  **What's preserved:**
+  - `td projects`, `td sections`, `td labels`, `td comments` — the flat plural aliases for the list case are permanent and not deprecated ([ADR-0001](docs/decisions/0001-design-principle.md) cites `td sections Blog` as a canonical example). Prefer them for muscle memory.
+  - `td comment <task_ref> <text>` — the flat shortcut for adding a comment without typing `add` is permanent.
+    ```bash
+    td comment 1 "Picked up 2%, not whole"       # still works
+    td comment "buy milk" "Got oat milk instead" # still works
+    ```
+
+  **Schema shape is additive** ([ADR-0006](docs/decisions/0006-schema-ai-contract.md)). Group commands gain a nested `commands` key in `td schema` output. Agents walking the top level now see `project`/`section`/`label`/`comment` as groups with subcommand trees rather than flat `project-*` entries. Flat command shape is unchanged. Agents that cached the old hyphenated CRUD names should re-fetch the schema on upgrade.
+  ```bash
+  td schema | jq '.commands.project.commands | keys'
+  # ["add","archive","delete","edit","list","unarchive"]
+  ```
+
+### Deprecated
+
+- **13 hyphenated CRUD names** deprecated in favor of the entity-group forms above. Old names still work in v0.13.0 but print a one-line stderr notice on every invocation. They are removed in v0.14.0.
+  ```
+  Note: td project-add is now td project add. The old name will be removed in v0.14.0.
+  ```
+  Affected: `project-add`, `project-edit`, `project-delete`, `project-archive`, `project-unarchive`, `section-add`, `section-edit`, `section-delete`, `label-add`, `label-edit`, `label-delete`, `comment-edit`, `comment-delete`.
+
 ### Internal
 
 - **Plan mode default, research-before-implement pattern, and ADR review checklist.** Three complementary safeguards against the #250 class of failure, adding the last three decisions from the workflow improvement plan:

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,6 +1,7 @@
 # Commands Reference
 
-td has 29 commands organized by function.
+td's commands are organized by function. Use `td <command> --help` for
+detailed options, or `td schema` for the full machine-readable manifest.
 
 ## Task Management
 
@@ -16,8 +17,6 @@ td has 29 commands organized by function.
 | [`td delete`](tasks.md#td-delete) | Delete a task |
 | [`td show`](tasks.md#td-show) | View full task details |
 | [`td search`](tasks.md#td-search) | Full-text search across all tasks |
-| [`td comment`](tasks.md#td-comment) | Add a comment to a task |
-| [`td comments`](tasks.md#td-comments) | List comments on a task |
 
 ## Workflow
 
@@ -33,14 +32,34 @@ td has 29 commands organized by function.
 
 ## Organization
 
+Entity groups for projects, sections, labels, and comments. Each group
+exposes `list`, `add`, `edit`, `delete` subcommands (plus `archive` /
+`unarchive` on `project`). The flat plural forms (`td projects`, etc.)
+are permanent shortcuts for the list case. See
+[ADR-0009](../decisions/0009-crud-verb-grammar.md) for the grammar
+decision.
+
 | Command | Description |
 |---------|-------------|
-| [`td projects`](organization.md#td-projects) | List projects |
-| [`td project-add`](organization.md#td-project-add) | Create a project |
-| [`td sections`](organization.md#td-sections) | List sections |
-| [`td section-add`](organization.md#td-section-add) | Create a section |
-| [`td labels`](organization.md#td-labels) | List labels |
-| [`td label-add`](organization.md#td-label-add) | Create a label |
+| [`td projects`](organization.md#td-projects-td-project-list) | List projects |
+| [`td project add`](organization.md#td-project-add) | Create a project |
+| [`td project edit`](organization.md#td-project-edit) | Rename or recolor a project |
+| [`td project delete`](organization.md#td-project-delete) | Delete a project |
+| [`td project archive`](organization.md#td-project-archive-unarchive) | Archive a project |
+| [`td project unarchive`](organization.md#td-project-archive-unarchive) | Unarchive a project |
+| [`td sections`](organization.md#td-sections-td-section-list) | List sections |
+| [`td section add`](organization.md#td-section-add) | Create a section in a project |
+| [`td section edit`](organization.md#td-section-edit) | Rename a section |
+| [`td section delete`](organization.md#td-section-delete) | Delete a section |
+| [`td labels`](organization.md#td-labels-td-label-list) | List labels |
+| [`td label add`](organization.md#td-label-add) | Create a label |
+| [`td label edit`](organization.md#td-label-edit) | Rename or recolor a label |
+| [`td label delete`](organization.md#td-label-delete) | Delete a label |
+| [`td comments`](organization.md#td-comments-td-comment-list) | List comments on a task |
+| [`td comment`](organization.md#td-comment-add) | Add a comment (flat shortcut) |
+| [`td comment add`](organization.md#td-comment-add) | Add a comment |
+| [`td comment edit`](organization.md#td-comment-edit) | Update a comment |
+| [`td comment delete`](organization.md#td-comment-delete) | Delete a comment |
 
 ## Utilities
 

--- a/docs/commands/organization.md
+++ b/docs/commands/organization.md
@@ -1,53 +1,194 @@
 # Organization Commands
 
-## td projects
+`td` organizes tasks around four entity types: **projects**, **sections**,
+**labels**, and **comments**. Each lives under an entity-first command group
+with the usual CRUD verbs (`list`, `add`, `edit`, `delete`, plus
+`archive`/`unarchive` for projects). The permanent flat plural aliases
+(`td projects`, `td sections`, etc.) stay as shortcuts for the common
+"show me the list" case.
+
+See [ADR-0009](../decisions/0009-crud-verb-grammar.md) for the grammar
+decision.
+
+## Projects
+
+### td projects / td project list
 
 List all projects.
 
 ```bash
 td projects
-td projects -s Work    # search by name
+td projects -s Work        # search by name
+td project list            # identical to the plural alias
 ```
 
-## td project-add
+### td project add
 
-Create a new project.
+Create a new project. Supports parent projects and favorites.
 
 ```bash
-td project-add "Side Projects"
-td project-add "Sub Project" --parent Work
-td project-add "Favorites" --favorite
+td project add "Home improvements"
+td project add "Q2 OKRs" --parent Work
+td project add "Favorites" --favorite
 ```
 
-## td sections
+### td project edit
 
-List sections in a project.
+Rename or recolor a project. The reference is a name or ID.
 
 ```bash
-td sections -p Work
+td project edit Work --name "Work stuff"
+td project edit Personal --color blue
 ```
 
-## td section-add
+### td project delete
 
-Create a new section in a project.
+Delete a project. Prompts for confirmation unless `-y` is passed.
 
 ```bash
-td section-add "In Progress" -p Work
+td project delete "Old Project" -y
 ```
 
-## td labels
+### td project archive / unarchive
+
+```bash
+td project archive "Finished Q1"
+td project unarchive "Finished Q1"
+```
+
+## Sections
+
+### td sections / td section list
+
+List sections. Without `-p`, sections from all projects are listed
+grouped by project.
+
+```bash
+td sections                # all sections, grouped by project
+td sections -p Work        # sections in one project
+td section list -p Work    # identical
+```
+
+### td section add
+
+Create a new section in a project. `-p`/`--project` is required.
+
+```bash
+td section add "Draft posts" -p Blog
+```
+
+### td section edit
+
+Rename a section. Use `-p` to scope the lookup if the same name exists
+in multiple projects.
+
+```bash
+td section edit "In Progress" --name "Active" -p Work
+```
+
+### td section delete
+
+```bash
+td section delete "Old Section" -p Work -y
+```
+
+## Labels
+
+### td labels / td label list
 
 List all labels.
 
 ```bash
 td labels
-td labels -s urgent    # search by name
+td labels -s urgent        # search by name
+td label list              # identical
 ```
 
-## td label-add
-
-Create a new label.
+### td label add
 
 ```bash
-td label-add important
+td label add urgent
+td label add work-critical
 ```
+
+### td label edit
+
+Rename or recolor a label.
+
+```bash
+td label edit urgent --name critical
+td label edit low --color green
+```
+
+### td label delete
+
+```bash
+td label delete old-label -y
+```
+
+## Comments
+
+### td comments / td comment list
+
+List comments on a task. Accepts a row number, content match, or task ID.
+
+```bash
+td comments 1              # row number from last ls
+td comments "buy milk"     # fuzzy content match
+td comment list 1          # identical
+```
+
+### td comment add
+
+Add a comment to a task. The flat shortcut `td comment <task_ref> <text>`
+also works — the explicit `add` verb is discoverable, the shortcut is
+the primary documented form.
+
+```bash
+td comment 1 "Picked up 2%, not whole"          # flat shortcut
+td comment "buy milk" "Got oat milk instead"    # flat shortcut
+td comment add 1 "Picked up 2%"                 # explicit form
+```
+
+### td comment edit
+
+Update a comment's content. Accepts the new content as positional args
+or via `--content`.
+
+```bash
+td comment edit abc123 "Updated text"
+td comment edit abc123 --content "Updated text"
+```
+
+### td comment delete
+
+```bash
+td comment delete abc123 -y
+```
+
+## Deprecated names
+
+The 13 hyphenated CRUD commands from v0.12.x still work in v0.13.0 but
+print a one-line deprecation notice on stderr. They are removed in
+v0.14.0 per [ADR-0009](../decisions/0009-crud-verb-grammar.md).
+
+| Old (v0.12.x)         | New (v0.13.0+)        |
+| --------------------- | --------------------- |
+| `td project-add`      | `td project add`      |
+| `td project-edit`     | `td project edit`     |
+| `td project-delete`   | `td project delete`   |
+| `td project-archive`  | `td project archive`  |
+| `td project-unarchive`| `td project unarchive`|
+| `td section-add`      | `td section add`      |
+| `td section-edit`     | `td section edit`     |
+| `td section-delete`   | `td section delete`   |
+| `td label-add`        | `td label add`        |
+| `td label-edit`       | `td label edit`       |
+| `td label-delete`     | `td label delete`     |
+| `td comment-edit`     | `td comment edit`     |
+| `td comment-delete`   | `td comment delete`   |
+
+The flat plural aliases (`td projects`, `td sections`, `td labels`,
+`td comments`) and the flat comment shortcut (`td comment <task> <text>`)
+are **not** deprecated. They are permanent shortcuts that match how
+humans naturally ask for the list and add a note.

--- a/docs/decisions/0009-crud-verb-grammar.md
+++ b/docs/decisions/0009-crud-verb-grammar.md
@@ -1,0 +1,198 @@
+# ADR-0009: CRUD verb grammar for entity commands
+
+## Status
+
+Accepted
+
+## Context
+
+PR #241 (closing issue #217) shipped 13 CRUD commands as hyphenated flat
+compounds: `project-add`, `project-edit`, `project-delete`,
+`project-archive`, `project-unarchive`, `section-add`, `section-edit`,
+`section-delete`, `label-add`, `label-edit`, `label-delete`, `comment-edit`,
+`comment-delete`. The grammar mirrored the Todoist REST API endpoint
+pattern (one verb per endpoint, entity name as prefix), not user intent.
+
+Issue #250 flagged this as a violation of ADR-0001 (*"accept what the user
+means, not what the system needs"*). `td project-edit Work --name "New
+Name"` reads like an API call. It is verbose, flag-heavy, and hides the
+entity relationship inside a hyphenated compound. Command trees that
+grow this way stop scaling gracefully as new entities are added
+(`filter`, `reminder`, `notification`, `attachment`, `settings` are all
+pending in the backlog).
+
+The command set is used by two audiences: humans at terminals and AI
+agents calling `td` via the `td schema` contract. The grammar decision
+must serve both. Humans benefit from progressive disclosure, tab
+completion, and muscle-memory alignment with other modern CLIs they
+already know. Agents benefit from a cleanly nested schema and consistent
+verb vocabulary across entities.
+
+## Alternatives considered
+
+**Option A: entity-first with ref before verb (`td project Work edit`).**
+Places the entity name and target before the verb. Reads naturally in
+English. Rejected because it fights Click's positional parsing model
+(Click expects subcommands in a fixed position, not after a free-form
+positional argument), breaks tab completion of verbs (the first
+positional is a project name which has no static completion set), and
+has no precedent in any comparable CLI.
+
+**Option A2: entity-first with verb before ref (`td project edit Work`).**
+Click-native: an entity group with verbs as subcommands and the ref as
+the subcommand's positional argument. Matches `gh pr edit 123`,
+`kubectl get pods`, `docker container inspect`. Tab completion works
+cleanly: `td project <TAB>` lists verbs from the static subcommand set;
+`td project edit <TAB>` dispatches to the existing `_complete_projects`
+helper. `td schema` becomes a two-level nested tree.
+
+**Option B: verb-first (`td rename project Work "New Name"`).** Flat
+global verb namespace; entity type is a positional argument after the
+verb. Rejected because it cross-cuts entity modules (verbs live in their
+own files, entities live in theirs), loses tab-completion context (the
+user selects a verb without the system knowing which entity it applies
+to), and only `git` uses verb-first among comparable CLIs. `git`'s verbs
+(`commit`, `rebase`, `checkout`) are primitives, not CRUD on nouns, so
+its model doesn't carry over.
+
+**Option C: smart context detection (`td edit Work --name "New Name"`).**
+A top-level `edit` command that inspects `Work` and resolves it to a
+project, section, label, or task by lookup. Rejected because it is
+ambiguous when names collide across entity types (a project and a label
+can share a name), requires a resolver-layer picker that doesn't exist,
+and violates ADR-0001 §3 (*"help the user recover when things go
+wrong"*) by introducing ambiguity where the user already knows which
+entity they mean. The smart path is magic that fights the explicit
+design principle.
+
+**Status quo (hyphenated compounds).** The pattern we are replacing.
+Rejected: the issue we are solving.
+
+## Decision
+
+**Use Option A2: entity-first Click groups with verb subcommands.**
+
+```
+td project add "Home improvements" --color blue
+td project edit Work --name "Work & side projects"
+td project delete Archive -y
+td project archive Old
+td project unarchive Old
+td section add "Draft posts" -p Blog
+td label delete urgent
+td comment edit <comment_id> --content "Updated comment"
+td comment delete <comment_id>
+```
+
+Four entity groups replace the 13 hyphenated flat commands:
+
+- `project` with `add`, `edit`, `delete`, `archive`, `unarchive`, `list`
+- `section` with `add`, `edit`, `delete`, `list`
+- `label` with `add`, `edit`, `delete`, `list`
+- `comment` with `add`, `edit`, `delete`, `list`
+
+**Hybrid decisions that preserve high-value ergonomics:**
+
+- **The plural list commands (`td projects`, `td sections`, `td labels`,
+  `td comments`) stay as permanent flat shortcuts.** Not deprecated.
+  ADR-0001 itself cites `td sections Blog` as a canonical example of
+  "accept what the user means." Deprecating the plurals would regress
+  against our own stated principle. `td project list` exists as a
+  discoverable synonym inside the group; the plural is the shortest
+  path to the most common operation.
+- **`td comment <task_ref> <text>` stays as a permanent flat shortcut.**
+  Implemented via `@click.group(invoke_without_command=True)` that
+  inspects residual args and delegates to the `add` subcommand. The flat
+  form is the primary documented usage and breaking it buys nothing.
+
+**Deprecation window for the 13 hyphenated names:**
+
+- **v0.13.0 (this change):** all 13 names ship as hidden aliases
+  (`@click.command(hidden=True)`) that emit a one-line stderr
+  deprecation notice and delegate to the new subcommand via
+  `ctx.invoke(...)`. Pattern matches `quick` and `capture` in
+  `src/td/cli/tasks.py:1028`.
+- **v0.14.0:** hidden aliases removed.
+
+Warning text format:
+
+```
+Note: td project-add is now td project add. The old name will be
+removed in v0.14.0.
+```
+
+Emitted on every invocation (no per-session deduplication). Keeps the
+shim code minimal and matches the existing alias pattern.
+
+**Schema recursion is a required sibling change (ADR-0006 territory).**
+
+`src/td/schema.py`'s `generate_schema` currently does not recurse into
+groups. Under A2, the four new entity groups would appear as bare
+entries with no subcommand information, breaking the `td schema`
+contract for agents. The fix is to detect `click.Group` instances during
+the walk and emit a nested `"commands"` dict on the entry, recursively
+applying the same filter (hidden commands excluded at every level).
+
+This is an **additive** schema shape change: flat commands remain
+shape-identical to before. Agents walking the top level now see
+`project`/`section`/`label`/`comment` as groups with `commands` keys
+rather than 13 flat `project-*`/`section-*`/`label-*`/`comment-*`
+entries. Called out explicitly in the CHANGELOG under `Changed`.
+
+## Consequences
+
+**Positive.**
+
+- **Aligns with ADR-0001.** Entity groups read like intent, not
+  endpoints. `td project edit Work --name "New"` is shorter, clearer,
+  and matches how humans talk about the action.
+- **Cross-CLI precedent.** `gh` (the most prominent agent-friendly CLI),
+  `kubectl`, and `docker` all use entity-first verb-subcommand patterns.
+  Users who know those tools transfer their muscle memory at zero cost.
+- **Tab completion improves dramatically.** `td project <TAB>` lists
+  verbs from the static subcommand set; `td project edit <TAB>` runs
+  `_complete_projects`. No new completion machinery required.
+- **Command tree scales.** Adding future CRUD operations
+  (e.g. `project move`, `project clone`) has an obvious home. New
+  entities (`filter`, `reminder`, `notification`) become new groups
+  following the same pattern, which unblocks #212, #221, #222, #225,
+  #226 and similar backlog items.
+- **Schema becomes navigable.** `td schema | jq '.commands.project'`
+  returns the full project verb tree for an agent to traverse, rather
+  than requiring pattern-matching on flat name prefixes.
+- **The hybrid preserves ergonomic wins.** Permanent plural list
+  commands keep the common case short, and the permanent `td comment`
+  flat shortcut preserves the primary documented usage.
+
+**Negative.**
+
+- **One-cycle deprecation tax.** 13 hidden alias shims live in the CLI
+  for v0.13.0 → v0.14.0. The shims are mechanical wrappers (one line
+  each for the notice plus a `ctx.invoke` call), and they are excluded
+  from help output and schema, but they add code surface during the
+  window.
+- **`td schema` shape changes.** Agents that cached the flat CRUD names
+  must re-fetch the schema on upgrade. This is called out in the
+  CHANGELOG as an additive change per ADR-0006.
+- **Documentation regeneration.** `docs/commands/organization.md` and
+  the AI skill (`SKILL.md`) both need to reflect the new grammar.
+  Skill regeneration is mechanical (`td skill install` walks the
+  schema), but the command reference docs need manual rewriting.
+- **Users may type the old name out of muscle memory.** Mitigated by
+  the hidden aliases and the stderr deprecation notice. After v0.14.0
+  the old names fail fast with Click's default "No such command" error,
+  which is recoverable.
+
+**Boundary preserved.** No core logic changes — the refactor is
+entirely in `src/td/cli/` and `src/td/schema.py`. `core/` stays
+untouched. ADR-0005 holds.
+
+## References
+
+- Issue #250 (the original problem)
+- ADR-0001 (design principle — the rule the status quo violated)
+- ADR-0002 (JSON output envelope — unchanged by this decision)
+- ADR-0006 (schema as the AI contract — the additive shape change lives here)
+- ADR-0008 (Click over Typer — entity groups rely on Click's command tree)
+- ADR-0010 (issue triage decision framework — this ADR satisfies the
+  "Needs ADR" tier requirement for any future CRUD command additions)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -57,5 +57,6 @@ document, not a decision. Trim before accepting.
 | [0006](0006-schema-as-ai-contract.md) | Schema as the AI Contract    | Accepted |
 | [0007](0007-row-number-cache-ttl.md) | Row-Number Cache TTLs         | Accepted |
 | [0008](0008-click-over-typer.md) | Click over Typer                   | Accepted |
+| [0009](0009-crud-verb-grammar.md) | CRUD verb grammar for entity commands | Accepted |
 | [0010](0010-triage-framework.md) | Issue triage decision framework    | Accepted |
 | [0011](0011-dependency-tracking.md) | Dependency tracking between issues | Accepted |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
     - "ADR-0006: Schema as AI Contract": decisions/0006-schema-as-ai-contract.md
     - "ADR-0007: Cache TTLs": decisions/0007-row-number-cache-ttl.md
     - "ADR-0008: Click over Typer": decisions/0008-click-over-typer.md
+    - "ADR-0009: CRUD Verb Grammar": decisions/0009-crud-verb-grammar.md
     - "ADR-0010: Triage Framework": decisions/0010-triage-framework.md
     - "ADR-0011: Dependency Tracking": decisions/0011-dependency-tracking.md
   - Contributing: contributing.md

--- a/scripts/generate_examples.py
+++ b/scripts/generate_examples.py
@@ -402,19 +402,19 @@ def generate() -> str:
     output = run_cmd(["--json", "projects", "-s", "Work"], make_api())
     example("Search projects.", 'td --json projects -s "Work"', output)
 
-    # --- td project-add ---
-    output = run_cmd(["--json", "project-add", "Side Projects"], make_api())
-    example("Create a new project.", 'td --json project-add "Side Projects"', output)
+    # --- td project add ---
+    output = run_cmd(["--json", "project", "add", "Side Projects"], make_api())
+    example("Create a new project.", 'td --json project add "Side Projects"', output)
 
     # --- td sections ---
     output = run_cmd(["--json", "sections", "-p", "Work"], make_api())
     example("List sections in a project.", 'td --json sections -p "Work"', output)
 
-    # --- td section-add ---
-    output = run_cmd(["--json", "section-add", "In Progress", "-p", "Work"], make_api())
+    # --- td section add ---
+    output = run_cmd(["--json", "section", "add", "In Progress", "-p", "Work"], make_api())
     example(
         "Create a new section in a project.",
-        'td --json section-add "In Progress" -p "Work"',
+        'td --json section add "In Progress" -p "Work"',
         output,
     )
 
@@ -425,9 +425,9 @@ def generate() -> str:
     output = run_cmd(["--plain", "labels"], make_api())
     example("List labels (plain mode).", "td --plain labels", output)
 
-    # --- td label-add ---
-    output = run_cmd(["--json", "label-add", "urgent"], make_api())
-    example("Create a new label.", "td --json label-add urgent", output)
+    # --- td label add ---
+    output = run_cmd(["--json", "label", "add", "urgent"], make_api())
+    example("Create a new label.", "td --json label add urgent", output)
 
     # --- td schema ---
     heading("AI-Native Commands")
@@ -484,19 +484,23 @@ def generate() -> str:
         "delete",
         "quick",
         "comment",
+        "comment add",
         "comments",
+        "project",
+        "project add",
         "projects",
-        "project-add",
+        "section",
+        "section add",
         "sections",
-        "section-add",
+        "label",
+        "label add",
         "labels",
-        "label-add",
         "review",
         "rate-limit",
         "schema",
     ]
     for cmd in cmds:
-        output = run_cmd([cmd, "--help"])
+        output = run_cmd([*cmd.split(), "--help"])
         example("", f"td {cmd} --help", output)
 
     return "\n".join(lines)

--- a/src/td/cli/__init__.py
+++ b/src/td/cli/__init__.py
@@ -111,8 +111,9 @@ def _register_commands() -> None:
     from td.cli.comments import comment, comment_delete, comment_edit, comments
     from td.cli.config_cmd import completions, init
     from td.cli.doctor import doctor
-    from td.cli.labels import label_add, label_delete, label_edit, labels
+    from td.cli.labels import label, label_add, label_delete, label_edit, labels
     from td.cli.projects import (
+        project,
         project_add,
         project_archive,
         project_delete,
@@ -123,7 +124,13 @@ def _register_commands() -> None:
     from td.cli.rate_limit import rate_limit
     from td.cli.review import review
     from td.cli.schema_cmd import schema
-    from td.cli.sections import section_add, section_delete, section_edit, sections
+    from td.cli.sections import (
+        section,
+        section_add,
+        section_delete,
+        section_edit,
+        sections,
+    )
     from td.cli.skill_cmd import skill
     from td.cli.tasks import (
         add,
@@ -151,8 +158,6 @@ def _register_commands() -> None:
     cli.add_command(init)
     cli.add_command(completions)
     cli.add_command(doctor)
-    cli.add_command(comment)
-    cli.add_command(comments)
     cli.add_command(schema)
     cli.add_command(add)
     cli.add_command(ls)
@@ -174,17 +179,25 @@ def _register_commands() -> None:
     cli.add_command(show)
     cli.add_command(undo)
     cli.add_command(search)
+    # Entity groups (primary surface per ADR-0009).
+    cli.add_command(project)
+    cli.add_command(section)
+    cli.add_command(label)
+    cli.add_command(comment)
+    # Permanent flat plural aliases for the list case (ADR-0001).
     cli.add_command(projects)
+    cli.add_command(sections)
+    cli.add_command(labels)
+    cli.add_command(comments)
+    # Hidden deprecated CRUD shims removed in v0.14.0 (ADR-0009).
     cli.add_command(project_add)
     cli.add_command(project_edit)
     cli.add_command(project_delete)
     cli.add_command(project_archive)
     cli.add_command(project_unarchive)
-    cli.add_command(sections)
     cli.add_command(section_add)
     cli.add_command(section_edit)
     cli.add_command(section_delete)
-    cli.add_command(labels)
     cli.add_command(label_add)
     cli.add_command(label_edit)
     cli.add_command(label_delete)

--- a/src/td/cli/comments.py
+++ b/src/td/cli/comments.py
@@ -1,4 +1,20 @@
-"""Comments CLI commands."""
+"""Comments CLI commands.
+
+The ``comment`` command is a Click group with a custom
+:class:`CommentGroup` subclass that delegates to the ``add`` subcommand
+when the first positional argument is not one of the group's known
+subcommand names. This preserves the permanent flat shortcut
+``td comment <task_ref> <text>`` without requiring an explicit ``add``
+verb, while still exposing ``add``, ``edit``, ``delete``, and ``list``
+as discoverable subcommands under ``td comment --help``.
+
+The plural ``comments`` command is a separate flat list alias (same
+pattern as ``projects``, ``sections``, ``labels``).
+
+Hidden deprecated shims ``comment-edit`` and ``comment-delete`` keep old
+invocations working through v0.13.0 with a stderr warning. They will be
+removed in v0.14.0. See ADR-0009 for the full grammar decision.
+"""
 
 from __future__ import annotations
 
@@ -22,27 +38,38 @@ def _require_task(ref: str | None, api: Any) -> str:
     return _require_task_ref((ref,) if ref else (), api)
 
 
-@click.command()
-@click.argument("task_ref", required=False, default=None)
-@click.argument("text", nargs=-1, required=True)
-@click.pass_context
-def comment(ctx: click.Context, task_ref: str | None, text: tuple[str, ...]) -> None:
-    """Add a comment to a task. Accepts row number, content match, or task ID.
+def _deprecation_notice(old: str, new: str) -> str:
+    return f"Note: td {old} is now td {new}. The old name will be removed in v0.14.0."
 
-    \b
-    Examples:
-      td comment 1 "Picked up 2%, not whole"
-      td comment buy milk "Got oat milk instead"
+
+class CommentGroup(click.Group):
+    """Click group that falls through to ``add`` when the first positional
+    argument isn't a known subcommand.
+
+    Preserves the permanent flat shortcut ``td comment 1 "text"``
+    alongside the discoverable ``td comment add``, ``td comment edit``,
+    ``td comment delete``, ``td comment list`` subcommands. The only
+    ambiguity is a task literally named after a subcommand verb (e.g.
+    a task called "edit"); that case routes to the subcommand and the
+    user can disambiguate with ``td comment add edit "text"``.
     """
-    api = get_client()
-    fmt = _get_formatter(ctx)
-    task_id = _require_task(task_ref, api)
 
-    result = api.add_comment(content=" ".join(text), task_id=task_id)
-    fmt.success(
-        f"Comment added to task {task_id}",
-        {"comment_id": result.id, "task_id": task_id, "content": result.content},
-    )
+    def resolve_command(
+        self,
+        ctx: click.Context,
+        args: list[str],
+    ) -> tuple[str | None, click.Command | None, list[str]]:
+        if args and args[0] in self.commands:
+            return super().resolve_command(ctx, args)
+        add_cmd = self.commands.get("add")
+        if add_cmd is None:
+            return super().resolve_command(ctx, args)
+        return "add", add_cmd, args
+
+
+# ---------------------------------------------------------------------------
+# Permanent flat plural alias for the list case.
+# ---------------------------------------------------------------------------
 
 
 @click.command()
@@ -64,12 +91,84 @@ def comments(ctx: click.Context, task_ref: str | None) -> None:
     fmt.comment_list(all_comments)
 
 
-@click.command(name="comment-edit")
+# ---------------------------------------------------------------------------
+# comment entity group (primary surface per ADR-0009)
+#
+# Uses CommentGroup to preserve the permanent flat shortcut
+# ``td comment <task_ref> <text>`` when the first positional isn't a
+# known subcommand name.
+# ---------------------------------------------------------------------------
+
+
+@click.group(name="comment", cls=CommentGroup)
+@click.pass_context
+def comment(ctx: click.Context) -> None:
+    """Manage task comments (add, edit, delete, list).
+
+    Permanent flat shortcut preserved:
+
+    \b
+      td comment 1 "Picked up 2%, not whole"
+      td comment buy milk "Got oat milk instead"
+
+    Explicit subcommands also available:
+
+    \b
+      td comment add 1 "Picked up 2%"
+      td comment edit <comment_id> --content "Updated text"
+      td comment delete <comment_id> -y
+      td comment list 1
+    """
+    # All behavior is in subcommands; CommentGroup.resolve_command handles
+    # the fall-through case to ``add`` for the flat shortcut.
+
+
+@comment.command(name="add")
+@click.argument("task_ref", required=False, default=None)
+@click.argument("text", nargs=-1, required=True)
+@click.pass_context
+def _comment_add(
+    ctx: click.Context,
+    task_ref: str | None,
+    text: tuple[str, ...],
+) -> None:
+    """Add a comment to a task. Accepts row number, content match, or task ID.
+
+    \b
+    Examples:
+      td comment add 1 "Picked up 2%, not whole"
+      td comment buy milk "Got oat milk instead"    # flat shortcut also works
+    """
+    api = get_client()
+    fmt = _get_formatter(ctx)
+    task_id = _require_task(task_ref, api)
+
+    result = api.add_comment(content=" ".join(text), task_id=task_id)
+    fmt.success(
+        f"Comment added to task {task_id}",
+        {"comment_id": result.id, "task_id": task_id, "content": result.content},
+    )
+
+
+@comment.command(name="list")
+@click.argument("task_ref", required=False, default=None)
+@click.pass_context
+def _comment_list(ctx: click.Context, task_ref: str | None) -> None:
+    """List comments on a task. Same as ``td comments``."""
+    api = get_client()
+    fmt = _get_formatter(ctx)
+    task_id = _require_task(task_ref, api)
+
+    all_comments = [c for page in api.get_comments(task_id=task_id) for c in page]
+    fmt.comment_list(all_comments)
+
+
+@comment.command(name="edit")
 @click.argument("comment_id")
 @click.argument("content", nargs=-1)
 @click.option("--content", "content_flag", help="New comment content.")
 @click.pass_context
-def comment_edit(
+def _comment_edit(
     ctx: click.Context,
     comment_id: str,
     content: tuple[str, ...],
@@ -79,8 +178,8 @@ def comment_edit(
 
     \b
     Examples:
-      td comment-edit abc123 "Updated text"
-      td comment-edit abc123 --content "Updated text"
+      td comment edit abc123 "Updated text"
+      td comment edit abc123 --content "Updated text"
     """
     api = get_client()
     fmt = _get_formatter(ctx)
@@ -99,16 +198,16 @@ def comment_edit(
     )
 
 
-@click.command(name="comment-delete")
+@comment.command(name="delete")
 @click.argument("comment_id")
 @click.option("-y", "--yes", is_flag=True, help="Skip confirmation.")
 @click.pass_context
-def comment_delete(ctx: click.Context, comment_id: str, yes: bool) -> None:
+def _comment_delete(ctx: click.Context, comment_id: str, yes: bool) -> None:
     """Delete a comment by ID.
 
     \b
     Examples:
-      td comment-delete abc123 -y
+      td comment delete abc123 -y
     """
     api = get_client()
     fmt = _get_formatter(ctx)
@@ -122,3 +221,39 @@ def comment_delete(ctx: click.Context, comment_id: str, yes: bool) -> None:
         f"Deleted comment {comment_id}",
         {"comment_id": comment_id},
     )
+
+
+# ---------------------------------------------------------------------------
+# Hidden deprecated aliases (removed in v0.14.0)
+# ---------------------------------------------------------------------------
+
+
+@click.command(name="comment-edit", hidden=True)
+@click.argument("comment_id")
+@click.argument("content", nargs=-1)
+@click.option("--content", "content_flag")
+@click.pass_context
+def comment_edit(
+    ctx: click.Context,
+    comment_id: str,
+    content: tuple[str, ...],
+    content_flag: str | None,
+) -> None:
+    """Deprecated: use ``td comment edit``."""
+    click.echo(_deprecation_notice("comment-edit", "comment edit"), err=True)
+    ctx.invoke(
+        _comment_edit,
+        comment_id=comment_id,
+        content=content,
+        content_flag=content_flag,
+    )
+
+
+@click.command(name="comment-delete", hidden=True)
+@click.argument("comment_id")
+@click.option("-y", "--yes", is_flag=True)
+@click.pass_context
+def comment_delete(ctx: click.Context, comment_id: str, yes: bool) -> None:
+    """Deprecated: use ``td comment delete``."""
+    click.echo(_deprecation_notice("comment-delete", "comment delete"), err=True)
+    ctx.invoke(_comment_delete, comment_id=comment_id, yes=yes)

--- a/src/td/cli/labels.py
+++ b/src/td/cli/labels.py
@@ -1,8 +1,16 @@
-"""Labels CLI commands."""
+"""Labels CLI commands.
+
+Public surface: the ``label`` Click group (``add``, ``edit``, ``delete``,
+``list``) plus the permanent flat plural alias ``labels``.
+
+Hidden deprecated shims (``label-add``, ``label-edit``, ``label-delete``)
+keep old invocations working through v0.13.0 with a stderr warning. They
+will be removed in v0.14.0. See ADR-0009.
+"""
 
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 import click
 
@@ -16,40 +24,76 @@ def _get_formatter(ctx: click.Context) -> OutputFormatter:
     return cast(OutputFormatter, ctx.obj["formatter"])
 
 
+def _list_labels(api: Any, fmt: OutputFormatter, search: str | None) -> None:
+    """Shared listing implementation for ``td labels`` and ``td label list``."""
+    if search:
+        all_labels = [lbl for page in api.search_labels(query=search) for lbl in page]
+    else:
+        all_labels = _collect_labels(api)
+    fmt.label_list(all_labels)
+
+
+def _deprecation_notice(old: str, new: str) -> str:
+    return f"Note: td {old} is now td {new}. The old name will be removed in v0.14.0."
+
+
+# ---------------------------------------------------------------------------
+# Permanent flat plural alias
+# ---------------------------------------------------------------------------
+
+
 @click.command()
 @click.option("-s", "--search", help="Search labels by name.")
 @click.pass_context
 def labels(ctx: click.Context, search: str | None) -> None:
     """List all labels. Use -s to search by name."""
-    api = get_client()
-    fmt = _get_formatter(ctx)
-
-    if search:
-        all_labels = [lbl for page in api.search_labels(query=search) for lbl in page]
-    else:
-        all_labels = _collect_labels(api)
-
-    fmt.label_list(all_labels)
+    _list_labels(get_client(), _get_formatter(ctx), search)
 
 
-@click.command(name="label-add")
+# ---------------------------------------------------------------------------
+# label entity group (primary surface per ADR-0009)
+# ---------------------------------------------------------------------------
+
+
+@click.group(name="label", invoke_without_command=True)
+@click.pass_context
+def label(ctx: click.Context) -> None:
+    """Manage Todoist labels (add, edit, delete, list)."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(_label_list, search=None)
+
+
+@label.command(name="list")
+@click.option("-s", "--search", help="Search labels by name.")
+@click.pass_context
+def _label_list(ctx: click.Context, search: str | None) -> None:
+    """List all labels. Use -s to search by name."""
+    _list_labels(get_client(), _get_formatter(ctx), search)
+
+
+@label.command(name="add")
 @click.argument("name", nargs=-1, required=True)
 @click.pass_context
-def label_add(ctx: click.Context, name: tuple[str, ...]) -> None:
-    """Create a new label."""
+def _label_add(ctx: click.Context, name: tuple[str, ...]) -> None:
+    """Create a new label.
+
+    \b
+    Examples:
+      td label add urgent
+    """
     api = get_client()
     fmt = _get_formatter(ctx)
 
-    label = api.add_label(name=" ".join(name))
-    fmt.item_created("label", label)
+    lbl = api.add_label(name=" ".join(name))
+    fmt.item_created("label", lbl)
 
 
-@click.command(name="label-edit")
+@label.command(name="edit")
 @click.argument("ref", nargs=-1, required=True)
 @click.option("--name", help="New label name.")
 @click.option("--color", help="New label color.")
 @click.pass_context
-def label_edit(
+def _label_edit(
     ctx: click.Context,
     ref: tuple[str, ...],
     name: str | None,
@@ -59,8 +103,8 @@ def label_edit(
 
     \b
     Examples:
-      td label-edit urgent --name critical
-      td label-edit low --color green
+      td label edit urgent --name critical
+      td label edit low --color green
     """
     api = get_client()
     fmt = _get_formatter(ctx)
@@ -71,35 +115,75 @@ def label_edit(
             suggestion="Provide --name and/or --color.",
         )
 
-    label = resolve_label(api, " ".join(ref))
-    updated = update_label(api, label.id, name=name, color=color)
+    lbl = resolve_label(api, " ".join(ref))
+    updated = update_label(api, lbl.id, name=name, color=color)
     fmt.success(
         f"Updated label: {updated.name}",
         {"label_id": updated.id, "name": updated.name},
     )
 
 
-@click.command(name="label-delete")
+@label.command(name="delete")
 @click.argument("ref", nargs=-1, required=True)
 @click.option("-y", "--yes", is_flag=True, help="Skip confirmation.")
 @click.pass_context
-def label_delete(ctx: click.Context, ref: tuple[str, ...], yes: bool) -> None:
+def _label_delete(ctx: click.Context, ref: tuple[str, ...], yes: bool) -> None:
     """Delete a label. Ref is a name or ID.
 
     \b
     Examples:
-      td label-delete old-label -y
+      td label delete old-label -y
     """
     api = get_client()
     fmt = _get_formatter(ctx)
 
-    label = resolve_label(api, " ".join(ref))
-    if not yes and not click.confirm(f'Delete label "{label.name}"?', default=False):
+    lbl = resolve_label(api, " ".join(ref))
+    if not yes and not click.confirm(f'Delete label "{lbl.name}"?', default=False):
         click.echo("Aborted.")
         return
 
-    delete_label(api, label.id)
+    delete_label(api, lbl.id)
     fmt.success(
-        f"Deleted label: {label.name}",
-        {"label_id": label.id, "name": label.name},
+        f"Deleted label: {lbl.name}",
+        {"label_id": lbl.id, "name": lbl.name},
     )
+
+
+# ---------------------------------------------------------------------------
+# Hidden deprecated aliases (removed in v0.14.0)
+# ---------------------------------------------------------------------------
+
+
+@click.command(name="label-add", hidden=True)
+@click.argument("name", nargs=-1, required=True)
+@click.pass_context
+def label_add(ctx: click.Context, name: tuple[str, ...]) -> None:
+    """Deprecated: use ``td label add``."""
+    click.echo(_deprecation_notice("label-add", "label add"), err=True)
+    ctx.invoke(_label_add, name=name)
+
+
+@click.command(name="label-edit", hidden=True)
+@click.argument("ref", nargs=-1, required=True)
+@click.option("--name")
+@click.option("--color")
+@click.pass_context
+def label_edit(
+    ctx: click.Context,
+    ref: tuple[str, ...],
+    name: str | None,
+    color: str | None,
+) -> None:
+    """Deprecated: use ``td label edit``."""
+    click.echo(_deprecation_notice("label-edit", "label edit"), err=True)
+    ctx.invoke(_label_edit, ref=ref, name=name, color=color)
+
+
+@click.command(name="label-delete", hidden=True)
+@click.argument("ref", nargs=-1, required=True)
+@click.option("-y", "--yes", is_flag=True)
+@click.pass_context
+def label_delete(ctx: click.Context, ref: tuple[str, ...], yes: bool) -> None:
+    """Deprecated: use ``td label delete``."""
+    click.echo(_deprecation_notice("label-delete", "label delete"), err=True)
+    ctx.invoke(_label_delete, ref=ref, yes=yes)

--- a/src/td/cli/projects.py
+++ b/src/td/cli/projects.py
@@ -1,8 +1,19 @@
-"""Projects CLI command."""
+"""Projects CLI commands.
+
+Public command surface is the ``project`` Click group defined in this
+module (with ``add``, ``edit``, ``delete``, ``archive``, ``unarchive``,
+``list`` subcommands) plus the permanent flat plural alias ``projects``
+for the common "show me the list" case.
+
+The old hyphenated flat commands (``project-add`` etc.) are kept as
+hidden deprecated shims that emit a stderr notice and delegate to the
+new subcommands. They will be removed in v0.14.0. See ADR-0009 for the
+full grammar decision.
+"""
 
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 import click
 
@@ -24,23 +35,54 @@ def _get_formatter(ctx: click.Context) -> OutputFormatter:
     return cast(OutputFormatter, ctx.obj["formatter"])
 
 
+def _list_projects(api: Any, fmt: OutputFormatter, search: str | None) -> None:
+    """Shared listing implementation used by both ``td projects`` and ``td project list``."""
+    if search:
+        all_projects = [p for page in api.search_projects(query=search) for p in page]
+    else:
+        all_projects = _collect_projects(api)
+    fmt.project_list(all_projects)
+
+
+# ---------------------------------------------------------------------------
+# Permanent flat plural alias for the list case.
+#
+# ADR-0001 cites ``td sections Blog`` as a canonical example of "accept
+# what the user means, not what the system needs." Plural list commands
+# stay as permanent shortcuts and are not deprecated by ADR-0009.
+# ---------------------------------------------------------------------------
+
+
 @click.command()
 @click.option("-s", "--search", help="Search projects by name.")
 @click.pass_context
 def projects(ctx: click.Context, search: str | None) -> None:
     """List all projects. Use -s to search by name."""
-    api = get_client()
-    fmt = _get_formatter(ctx)
-
-    if search:
-        all_projects = [p for page in api.search_projects(query=search) for p in page]
-    else:
-        all_projects = _collect_projects(api)
-
-    fmt.project_list(all_projects)
+    _list_projects(get_client(), _get_formatter(ctx), search)
 
 
-@click.command(name="project-add")
+# ---------------------------------------------------------------------------
+# project entity group (primary surface per ADR-0009)
+# ---------------------------------------------------------------------------
+
+
+@click.group(name="project", invoke_without_command=True)
+@click.pass_context
+def project(ctx: click.Context) -> None:
+    """Manage Todoist projects (add, edit, delete, archive, unarchive, list)."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(_project_list, search=None)
+
+
+@project.command(name="list")
+@click.option("-s", "--search", help="Search projects by name.")
+@click.pass_context
+def _project_list(ctx: click.Context, search: str | None) -> None:
+    """List all projects. Use -s to search by name."""
+    _list_projects(get_client(), _get_formatter(ctx), search)
+
+
+@project.command(name="add")
 @click.argument("name", nargs=-1, required=True)
 @click.option(
     "--parent",
@@ -49,13 +91,19 @@ def projects(ctx: click.Context, search: str | None) -> None:
 )
 @click.option("--favorite", is_flag=True, help="Mark as favorite.")
 @click.pass_context
-def project_add(
+def _project_add(
     ctx: click.Context,
     name: tuple[str, ...],
     parent_name: str | None,
     favorite: bool,
 ) -> None:
-    """Create a new project."""
+    """Create a new project.
+
+    \b
+    Examples:
+      td project add "Home improvements"
+      td project add "Q2 OKRs" --parent Work
+    """
     api = get_client()
     fmt = _get_formatter(ctx)
 
@@ -63,21 +111,21 @@ def project_add(
     if parent_name:
         parent_id = resolve_project(api, parent_name).id
 
-    project = create_project(
+    proj = create_project(
         api,
         " ".join(name),
         parent_id=parent_id,
         is_favorite=favorite,
     )
-    fmt.item_created("project", project)
+    fmt.item_created("project", proj)
 
 
-@click.command(name="project-edit")
+@project.command(name="edit")
 @click.argument("ref", nargs=-1, required=True)
 @click.option("--name", help="New project name.")
 @click.option("--color", help="New project color.")
 @click.pass_context
-def project_edit(
+def _project_edit(
     ctx: click.Context,
     ref: tuple[str, ...],
     name: str | None,
@@ -87,8 +135,8 @@ def project_edit(
 
     \b
     Examples:
-      td project-edit Work --name "Work stuff"
-      td project-edit Personal --color blue
+      td project edit Work --name "Work stuff"
+      td project edit Personal --color blue
     """
     api = get_client()
     fmt = _get_formatter(ctx)
@@ -99,77 +147,149 @@ def project_edit(
             suggestion="Provide --name and/or --color.",
         )
 
-    project = resolve_project(api, " ".join(ref))
-    updated = update_project(api, project.id, name=name, color=color)
+    proj = resolve_project(api, " ".join(ref))
+    updated = update_project(api, proj.id, name=name, color=color)
     fmt.success(
         f"Updated project: {updated.name}",
         {"project_id": updated.id, "name": updated.name},
     )
 
 
-@click.command(name="project-delete")
+@project.command(name="delete")
 @click.argument("ref", nargs=-1, required=True)
 @click.option("-y", "--yes", is_flag=True, help="Skip confirmation.")
 @click.pass_context
-def project_delete(ctx: click.Context, ref: tuple[str, ...], yes: bool) -> None:
+def _project_delete(ctx: click.Context, ref: tuple[str, ...], yes: bool) -> None:
     """Delete a project. Ref is a name or ID.
 
     \b
     Examples:
-      td project-delete "Old Project" -y
+      td project delete "Old Project" -y
     """
     api = get_client()
     fmt = _get_formatter(ctx)
 
-    project = resolve_project(api, " ".join(ref))
-    if not yes and not click.confirm(f'Delete project "{project.name}"?', default=False):
+    proj = resolve_project(api, " ".join(ref))
+    if not yes and not click.confirm(f'Delete project "{proj.name}"?', default=False):
         click.echo("Aborted.")
         return
 
-    delete_project(api, project.id)
+    delete_project(api, proj.id)
     fmt.success(
-        f"Deleted project: {project.name}",
-        {"project_id": project.id, "name": project.name},
+        f"Deleted project: {proj.name}",
+        {"project_id": proj.id, "name": proj.name},
     )
 
 
-@click.command(name="project-archive")
+@project.command(name="archive")
 @click.argument("ref", nargs=-1, required=True)
 @click.pass_context
-def project_archive(ctx: click.Context, ref: tuple[str, ...]) -> None:
+def _project_archive(ctx: click.Context, ref: tuple[str, ...]) -> None:
     """Archive a project. Ref is a name or ID.
 
     \b
     Examples:
-      td project-archive "Old Project"
+      td project archive "Old Project"
     """
     api = get_client()
     fmt = _get_formatter(ctx)
 
-    project = resolve_project(api, " ".join(ref))
-    archive_project(api, project.id)
+    proj = resolve_project(api, " ".join(ref))
+    archive_project(api, proj.id)
     fmt.success(
-        f"Archived project: {project.name}",
-        {"project_id": project.id, "name": project.name},
+        f"Archived project: {proj.name}",
+        {"project_id": proj.id, "name": proj.name},
     )
 
 
-@click.command(name="project-unarchive")
+@project.command(name="unarchive")
 @click.argument("ref", nargs=-1, required=True)
 @click.pass_context
-def project_unarchive(ctx: click.Context, ref: tuple[str, ...]) -> None:
+def _project_unarchive(ctx: click.Context, ref: tuple[str, ...]) -> None:
     """Unarchive a project. Ref is a name or ID.
 
     \b
     Examples:
-      td project-unarchive "Old Project"
+      td project unarchive "Old Project"
     """
     api = get_client()
     fmt = _get_formatter(ctx)
 
-    project = resolve_project(api, " ".join(ref))
-    unarchive_project(api, project.id)
+    proj = resolve_project(api, " ".join(ref))
+    unarchive_project(api, proj.id)
     fmt.success(
-        f"Unarchived project: {project.name}",
-        {"project_id": project.id, "name": project.name},
+        f"Unarchived project: {proj.name}",
+        {"project_id": proj.id, "name": proj.name},
     )
+
+
+# ---------------------------------------------------------------------------
+# Hidden deprecated aliases (removed in v0.14.0 per ADR-0009).
+#
+# Each shim emits a one-line stderr notice and delegates via ``ctx.invoke``
+# to the new subcommand. Hidden from ``--help`` and from ``td schema``.
+# ---------------------------------------------------------------------------
+
+
+def _deprecation_notice(old: str, new: str) -> str:
+    return f"Note: td {old} is now td {new}. The old name will be removed in v0.14.0."
+
+
+@click.command(name="project-add", hidden=True)
+@click.argument("name", nargs=-1, required=True)
+@click.option("--parent", "parent_name")
+@click.option("--favorite", is_flag=True)
+@click.pass_context
+def project_add(
+    ctx: click.Context,
+    name: tuple[str, ...],
+    parent_name: str | None,
+    favorite: bool,
+) -> None:
+    """Deprecated: use ``td project add``."""
+    click.echo(_deprecation_notice("project-add", "project add"), err=True)
+    ctx.invoke(_project_add, name=name, parent_name=parent_name, favorite=favorite)
+
+
+@click.command(name="project-edit", hidden=True)
+@click.argument("ref", nargs=-1, required=True)
+@click.option("--name")
+@click.option("--color")
+@click.pass_context
+def project_edit(
+    ctx: click.Context,
+    ref: tuple[str, ...],
+    name: str | None,
+    color: str | None,
+) -> None:
+    """Deprecated: use ``td project edit``."""
+    click.echo(_deprecation_notice("project-edit", "project edit"), err=True)
+    ctx.invoke(_project_edit, ref=ref, name=name, color=color)
+
+
+@click.command(name="project-delete", hidden=True)
+@click.argument("ref", nargs=-1, required=True)
+@click.option("-y", "--yes", is_flag=True)
+@click.pass_context
+def project_delete(ctx: click.Context, ref: tuple[str, ...], yes: bool) -> None:
+    """Deprecated: use ``td project delete``."""
+    click.echo(_deprecation_notice("project-delete", "project delete"), err=True)
+    ctx.invoke(_project_delete, ref=ref, yes=yes)
+
+
+@click.command(name="project-archive", hidden=True)
+@click.argument("ref", nargs=-1, required=True)
+@click.pass_context
+def project_archive(ctx: click.Context, ref: tuple[str, ...]) -> None:
+    """Deprecated: use ``td project archive``."""
+    click.echo(_deprecation_notice("project-archive", "project archive"), err=True)
+    ctx.invoke(_project_archive, ref=ref)
+
+
+@click.command(name="project-unarchive", hidden=True)
+@click.argument("ref", nargs=-1, required=True)
+@click.pass_context
+def project_unarchive(ctx: click.Context, ref: tuple[str, ...]) -> None:
+    """Deprecated: use ``td project unarchive``."""
+    click.echo(_deprecation_notice("project-unarchive", "project unarchive"), err=True)
+    ctx.invoke(_project_unarchive, ref=ref)

--- a/src/td/cli/sections.py
+++ b/src/td/cli/sections.py
@@ -1,9 +1,17 @@
-"""Sections CLI commands."""
+"""Sections CLI commands.
+
+Public surface: the ``section`` Click group (``add``, ``edit``,
+``delete``, ``list``) plus the permanent flat plural alias ``sections``.
+
+Hidden deprecated shims (``section-add``, ``section-edit``,
+``section-delete``) keep old invocations working through v0.13.0 with a
+stderr warning. They will be removed in v0.14.0. See ADR-0009.
+"""
 
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import cast
+from typing import Any, cast
 
 import click
 from todoist_api_python.models import Section
@@ -19,6 +27,34 @@ def _get_formatter(ctx: click.Context) -> OutputFormatter:
     return cast(OutputFormatter, ctx.obj["formatter"])
 
 
+def _list_sections(api: Any, fmt: OutputFormatter, project_name: str | None) -> None:
+    """Shared listing implementation for ``td sections`` and ``td section list``."""
+    if project_name:
+        project = resolve_project(api, project_name)
+        all_sections = _collect_sections(api, project_id=project.id)
+        fmt.section_list(all_sections)
+        return
+
+    all_sections = _collect_sections(api)
+    if not all_sections:
+        fmt.section_list([])
+        return
+    pnames = get_project_name_map(api)
+    grouped: dict[str, list[Section]] = defaultdict(list)
+    for s in all_sections:
+        grouped[s.project_id].append(s)
+    fmt.section_list_grouped(grouped, pnames)
+
+
+def _deprecation_notice(old: str, new: str) -> str:
+    return f"Note: td {old} is now td {new}. The old name will be removed in v0.14.0."
+
+
+# ---------------------------------------------------------------------------
+# Permanent flat plural alias
+# ---------------------------------------------------------------------------
+
+
 @click.command()
 @click.option(
     "-p",
@@ -30,26 +66,37 @@ def _get_formatter(ctx: click.Context) -> OutputFormatter:
 @click.pass_context
 def sections(ctx: click.Context, project_name: str | None) -> None:
     """List sections, optionally scoped to a project."""
-    api = get_client()
-    fmt = _get_formatter(ctx)
-
-    if project_name:
-        project = resolve_project(api, project_name)
-        all_sections = _collect_sections(api, project_id=project.id)
-        fmt.section_list(all_sections)
-    else:
-        all_sections = _collect_sections(api)
-        if not all_sections:
-            fmt.section_list([])
-            return
-        pnames = get_project_name_map(api)
-        grouped: dict[str, list[Section]] = defaultdict(list)
-        for s in all_sections:
-            grouped[s.project_id].append(s)
-        fmt.section_list_grouped(grouped, pnames)
+    _list_sections(get_client(), _get_formatter(ctx), project_name)
 
 
-@click.command(name="section-add")
+# ---------------------------------------------------------------------------
+# section entity group (primary surface per ADR-0009)
+# ---------------------------------------------------------------------------
+
+
+@click.group(name="section", invoke_without_command=True)
+@click.pass_context
+def section(ctx: click.Context) -> None:
+    """Manage Todoist sections (add, edit, delete, list)."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(_section_list, project_name=None)
+
+
+@section.command(name="list")
+@click.option(
+    "-p",
+    "--project",
+    "project_name",
+    help="Scope to a project. Without this, lists all sections grouped by project.",
+    shell_complete=_complete_projects,
+)
+@click.pass_context
+def _section_list(ctx: click.Context, project_name: str | None) -> None:
+    """List sections, optionally scoped to a project."""
+    _list_sections(get_client(), _get_formatter(ctx), project_name)
+
+
+@section.command(name="add")
 @click.argument("name", nargs=-1, required=True)
 @click.option(
     "-p",
@@ -60,17 +107,22 @@ def sections(ctx: click.Context, project_name: str | None) -> None:
     shell_complete=_complete_projects,
 )
 @click.pass_context
-def section_add(ctx: click.Context, name: tuple[str, ...], project_name: str) -> None:
-    """Create a new section in a project. Requires -p/--project."""
+def _section_add(ctx: click.Context, name: tuple[str, ...], project_name: str) -> None:
+    """Create a new section in a project. Requires -p/--project.
+
+    \b
+    Examples:
+      td section add "Draft posts" -p Blog
+    """
     api = get_client()
     fmt = _get_formatter(ctx)
 
     project = resolve_project(api, project_name)
-    section = api.add_section(name=" ".join(name), project_id=project.id)
-    fmt.item_created("section", section)
+    sec = api.add_section(name=" ".join(name), project_id=project.id)
+    fmt.item_created("section", sec)
 
 
-@click.command(name="section-edit")
+@section.command(name="edit")
 @click.argument("ref", nargs=-1, required=True)
 @click.option("--name", required=True, help="New section name.")
 @click.option(
@@ -81,7 +133,7 @@ def section_add(ctx: click.Context, name: tuple[str, ...], project_name: str) ->
     shell_complete=_complete_projects,
 )
 @click.pass_context
-def section_edit(
+def _section_edit(
     ctx: click.Context,
     ref: tuple[str, ...],
     name: str,
@@ -91,7 +143,7 @@ def section_edit(
 
     \b
     Examples:
-      td section-edit "In Progress" --name "Active" -p Work
+      td section edit "In Progress" --name "Active" -p Work
     """
     api = get_client()
     fmt = _get_formatter(ctx)
@@ -100,15 +152,15 @@ def section_edit(
     if project_name:
         project_id = resolve_project(api, project_name).id
 
-    section = resolve_section(api, " ".join(ref), project_id=project_id)
-    updated = update_section(api, section.id, name=name)
+    sec = resolve_section(api, " ".join(ref), project_id=project_id)
+    updated = update_section(api, sec.id, name=name)
     fmt.success(
         f"Updated section: {updated.name}",
         {"section_id": updated.id, "name": updated.name},
     )
 
 
-@click.command(name="section-delete")
+@section.command(name="delete")
 @click.argument("ref", nargs=-1, required=True)
 @click.option("-y", "--yes", is_flag=True, help="Skip confirmation.")
 @click.option(
@@ -119,7 +171,7 @@ def section_edit(
     shell_complete=_complete_projects,
 )
 @click.pass_context
-def section_delete(
+def _section_delete(
     ctx: click.Context,
     ref: tuple[str, ...],
     yes: bool,
@@ -129,7 +181,7 @@ def section_delete(
 
     \b
     Examples:
-      td section-delete "Old Section" -p Work -y
+      td section delete "Old Section" -p Work -y
     """
     api = get_client()
     fmt = _get_formatter(ctx)
@@ -138,13 +190,76 @@ def section_delete(
     if project_name:
         project_id = resolve_project(api, project_name).id
 
-    section = resolve_section(api, " ".join(ref), project_id=project_id)
-    if not yes and not click.confirm(f'Delete section "{section.name}"?', default=False):
+    sec = resolve_section(api, " ".join(ref), project_id=project_id)
+    if not yes and not click.confirm(f'Delete section "{sec.name}"?', default=False):
         click.echo("Aborted.")
         return
 
-    delete_section(api, section.id)
+    delete_section(api, sec.id)
     fmt.success(
-        f"Deleted section: {section.name}",
-        {"section_id": section.id, "name": section.name},
+        f"Deleted section: {sec.name}",
+        {"section_id": sec.id, "name": sec.name},
     )
+
+
+# ---------------------------------------------------------------------------
+# Hidden deprecated aliases (removed in v0.14.0)
+# ---------------------------------------------------------------------------
+
+
+@click.command(name="section-add", hidden=True)
+@click.argument("name", nargs=-1, required=True)
+@click.option(
+    "-p",
+    "--project",
+    "project_name",
+    required=True,
+    shell_complete=_complete_projects,
+)
+@click.pass_context
+def section_add(ctx: click.Context, name: tuple[str, ...], project_name: str) -> None:
+    """Deprecated: use ``td section add``."""
+    click.echo(_deprecation_notice("section-add", "section add"), err=True)
+    ctx.invoke(_section_add, name=name, project_name=project_name)
+
+
+@click.command(name="section-edit", hidden=True)
+@click.argument("ref", nargs=-1, required=True)
+@click.option("--name", required=True)
+@click.option(
+    "-p",
+    "--project",
+    "project_name",
+    shell_complete=_complete_projects,
+)
+@click.pass_context
+def section_edit(
+    ctx: click.Context,
+    ref: tuple[str, ...],
+    name: str,
+    project_name: str | None,
+) -> None:
+    """Deprecated: use ``td section edit``."""
+    click.echo(_deprecation_notice("section-edit", "section edit"), err=True)
+    ctx.invoke(_section_edit, ref=ref, name=name, project_name=project_name)
+
+
+@click.command(name="section-delete", hidden=True)
+@click.argument("ref", nargs=-1, required=True)
+@click.option("-y", "--yes", is_flag=True)
+@click.option(
+    "-p",
+    "--project",
+    "project_name",
+    shell_complete=_complete_projects,
+)
+@click.pass_context
+def section_delete(
+    ctx: click.Context,
+    ref: tuple[str, ...],
+    yes: bool,
+    project_name: str | None,
+) -> None:
+    """Deprecated: use ``td section delete``."""
+    click.echo(_deprecation_notice("section-delete", "section delete"), err=True)
+    ctx.invoke(_section_delete, ref=ref, yes=yes, project_name=project_name)

--- a/src/td/core/skill.py
+++ b/src/td/core/skill.py
@@ -57,6 +57,48 @@ def needs_update(agent: str) -> bool:
     return ver != __version__
 
 
+def _emit_command(lines: list[str], path: str, cmd_info: dict[str, Any]) -> None:
+    """Emit a single command section. Recurses into groups so that entity
+    groups introduced by ADR-0009 (project, section, label, comment)
+    expose their verbs to agents as fully-qualified invocations like
+    ``td project add`` rather than a bare group header.
+    """
+    desc = cmd_info.get("description", "").split("\n")[0].strip()
+    lines.append(f"### td {path}")
+    lines.append("")
+    if desc:
+        lines.append(desc)
+        lines.append("")
+
+    args = cmd_info.get("arguments", [])
+    if args:
+        for arg in args:
+            req = " (required)" if arg.get("required") else ""
+            lines.append(f"- `{arg['name']}` — {arg['type']}{req}")
+        lines.append("")
+
+    opts = cmd_info.get("options", [])
+    if opts:
+        for opt in opts:
+            flags = ", ".join(opt.get("flags", []))
+            help_text = opt.get("help", "")
+            if opt.get("is_flag"):
+                lines.append(f"- `{flags}` — {help_text}")
+            else:
+                default = opt.get("default")
+                default_str = f" (default: {default})" if default is not None else ""
+                lines.append(f"- `{flags}` — {help_text}{default_str}")
+        lines.append("")
+
+    # Recurse into group subcommands. The schema emits a ``commands`` key
+    # on group entries (see schema._command_schema) so an agent walking
+    # this file sees every invocable verb, not just the group name.
+    subcommands = cmd_info.get("commands")
+    if subcommands:
+        for sub_name, sub_info in sorted(subcommands.items()):
+            _emit_command(lines, f"{path} {sub_name}", sub_info)
+
+
 def generate_skill_content(schema: dict[str, Any]) -> str:
     """Generate SKILL.md content from the command schema."""
     lines: list[str] = []
@@ -92,34 +134,7 @@ def generate_skill_content(schema: dict[str, Any]) -> str:
     lines.append("")
 
     for cmd_name, cmd_info in sorted(schema.get("commands", {}).items()):
-        desc = cmd_info.get("description", "").split("\n")[0].strip()
-        lines.append(f"### td {cmd_name}")
-        lines.append("")
-        if desc:
-            lines.append(desc)
-            lines.append("")
-
-        # Arguments
-        args = cmd_info.get("arguments", [])
-        if args:
-            for arg in args:
-                req = " (required)" if arg.get("required") else ""
-                lines.append(f"- `{arg['name']}` — {arg['type']}{req}")
-            lines.append("")
-
-        # Options
-        opts = cmd_info.get("options", [])
-        if opts:
-            for opt in opts:
-                flags = ", ".join(opt.get("flags", []))
-                help_text = opt.get("help", "")
-                if opt.get("is_flag"):
-                    lines.append(f"- `{flags}` — {help_text}")
-                else:
-                    default = opt.get("default")
-                    default_str = f" (default: {default})" if default is not None else ""
-                    lines.append(f"- `{flags}` — {help_text}{default_str}")
-            lines.append("")
+        _emit_command(lines, cmd_name, cmd_info)
 
     # Environment variables
     lines.append("## Environment variables")

--- a/src/td/schema.py
+++ b/src/td/schema.py
@@ -43,8 +43,16 @@ def _param_schema(param: click.Parameter) -> dict[str, Any]:
 
 
 def _command_schema(cmd: click.Command) -> dict[str, Any]:
-    """Extract schema for a single command."""
-    return {
+    """Extract schema for a single command (leaf or group).
+
+    When ``cmd`` is a :class:`click.Group`, the returned schema also
+    carries a nested ``commands`` dict describing the group's non-hidden
+    subcommands. This lets agents walk an entity group (``project``,
+    ``section``, ``label``, ``comment``) and discover its verbs without
+    guessing at flat name prefixes. See ADR-0009 for the entity-group
+    grammar and ADR-0006 for the AI contract implications.
+    """
+    schema: dict[str, Any] = {
         "description": cmd.help or "",
         "arguments": [_param_schema(p) for p in cmd.params if isinstance(p, click.Argument)],
         "options": [
@@ -53,6 +61,14 @@ def _command_schema(cmd: click.Command) -> dict[str, Any]:
             if isinstance(p, click.Option) and p.name not in ("help",)
         ],
     }
+    if isinstance(cmd, click.Group):
+        subcommands: dict[str, Any] = {}
+        for sub_name, sub_cmd in sorted(cmd.commands.items()):
+            if getattr(sub_cmd, "hidden", False):
+                continue
+            subcommands[sub_name] = _command_schema(sub_cmd)
+        schema["commands"] = subcommands
+    return schema
 
 
 def generate_schema(cli_group: click.Group) -> dict[str, Any]:

--- a/tests/test_org_commands.py
+++ b/tests/test_org_commands.py
@@ -94,7 +94,7 @@ class TestProjectAddCommand:
         api.add_project.return_value = proj
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-add", "New", "Project"])
+        result = runner.invoke(cli, ["--json", "project", "add", "New", "Project"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -113,7 +113,7 @@ class TestProjectAddCommand:
 
         runner = CliRunner()
         result = runner.invoke(
-            cli, ["--json", "project-add", "Sub", "Project", "--parent", "Work"]
+            cli, ["--json", "project", "add", "Sub", "Project", "--parent", "Work"]
         )
 
         assert result.exit_code == 0
@@ -127,7 +127,7 @@ class TestProjectAddCommand:
         api.add_project.return_value = _mock_project(name="Fav", is_favorite=True)
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-add", "Fav", "--favorite"])
+        result = runner.invoke(cli, ["--json", "project", "add", "Fav", "--favorite"])
 
         assert result.exit_code == 0
         _, kwargs = api.add_project.call_args
@@ -205,7 +205,7 @@ class TestSectionAddCommand:
         api.add_section.return_value = _mock_section(name="In Progress")
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "section-add", "In", "Progress", "-p", "Work"])
+        result = runner.invoke(cli, ["--json", "section", "add", "In", "Progress", "-p", "Work"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -216,7 +216,7 @@ class TestSectionAddCommand:
     @patch("td.cli.sections.get_client")
     def test_section_add_requires_project(self, mock_gc: MagicMock) -> None:
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "section-add", "Test"])
+        result = runner.invoke(cli, ["--json", "section", "add", "Test"])
 
         assert result.exit_code != 0
         assert "project" in result.output.lower() or "required" in result.output.lower()
@@ -244,7 +244,7 @@ class TestLabelsCommand:
         api.add_label.return_value = _mock_label(name="important")
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "label-add", "important"])
+        result = runner.invoke(cli, ["--json", "label", "add", "important"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -280,7 +280,7 @@ class TestProjectEditCommand:
         api.update_project.return_value = updated
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-edit", "Work", "--name", "Work stuff"])
+        result = runner.invoke(cli, ["--json", "project", "edit", "Work", "--name", "Work stuff"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -298,7 +298,7 @@ class TestProjectEditCommand:
         api.update_project.return_value = updated
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-edit", "Work", "--color", "blue"])
+        result = runner.invoke(cli, ["--json", "project", "edit", "Work", "--color", "blue"])
 
         assert result.exit_code == 0
         api.update_project.assert_called_once_with("p1", name=None, color="blue")
@@ -306,7 +306,7 @@ class TestProjectEditCommand:
     @patch("td.cli.projects.get_client")
     def test_edit_no_flags_errors(self, mock_gc: MagicMock) -> None:
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-edit", "Work"])
+        result = runner.invoke(cli, ["--json", "project", "edit", "Work"])
 
         assert result.exit_code == 1
 
@@ -320,7 +320,7 @@ class TestProjectDeleteCommand:
         api.get_projects.return_value = iter([[proj]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-delete", "Old", "-y"])
+        result = runner.invoke(cli, ["--json", "project", "delete", "Old", "-y"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -335,7 +335,7 @@ class TestProjectDeleteCommand:
         api.get_projects.return_value = iter([[proj]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-delete", "Old"], input="y\n")
+        result = runner.invoke(cli, ["--json", "project", "delete", "Old"], input="y\n")
 
         assert result.exit_code == 0
         api.delete_project.assert_called_once_with("p1")
@@ -348,7 +348,7 @@ class TestProjectDeleteCommand:
         api.get_projects.return_value = iter([[proj]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-delete", "Old"], input="n\n")
+        result = runner.invoke(cli, ["--json", "project", "delete", "Old"], input="n\n")
 
         assert result.exit_code == 0
         api.delete_project.assert_not_called()
@@ -360,7 +360,7 @@ class TestProjectDeleteCommand:
         api.get_projects.return_value = iter([[]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-delete", "Nonexistent", "-y"])
+        result = runner.invoke(cli, ["--json", "project", "delete", "Nonexistent", "-y"])
 
         assert result.exit_code == 1
 
@@ -374,7 +374,7 @@ class TestProjectArchiveCommand:
         api.get_projects.return_value = iter([[proj]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-archive", "Work"])
+        result = runner.invoke(cli, ["--json", "project", "archive", "Work"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -391,7 +391,7 @@ class TestProjectUnarchiveCommand:
         api.get_projects.return_value = iter([[proj]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "project-unarchive", "Work"])
+        result = runner.invoke(cli, ["--json", "project", "unarchive", "Work"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -416,7 +416,7 @@ class TestSectionEditCommand:
 
         runner = CliRunner()
         result = runner.invoke(
-            cli, ["--json", "section-edit", "Backlog", "--name", "Active", "-p", "Work"]
+            cli, ["--json", "section", "edit", "Backlog", "--name", "Active", "-p", "Work"]
         )
 
         assert result.exit_code == 0
@@ -435,7 +435,7 @@ class TestSectionEditCommand:
         api.update_section.return_value = updated
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "section-edit", "Backlog", "--name", "Active"])
+        result = runner.invoke(cli, ["--json", "section", "edit", "Backlog", "--name", "Active"])
 
         assert result.exit_code == 0
         api.update_section.assert_called_once_with("s1", name="Active")
@@ -450,7 +450,7 @@ class TestSectionDeleteCommand:
         api.get_sections.return_value = iter([[sec]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "section-delete", "Old", "-y"])
+        result = runner.invoke(cli, ["--json", "section", "delete", "Old", "-y"])
 
         assert result.exit_code == 0
         api.delete_section.assert_called_once_with("s1")
@@ -463,7 +463,7 @@ class TestSectionDeleteCommand:
         api.get_sections.return_value = iter([[sec]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "section-delete", "Old"], input="y\n")
+        result = runner.invoke(cli, ["--json", "section", "delete", "Old"], input="y\n")
 
         assert result.exit_code == 0
         api.delete_section.assert_called_once_with("s1")
@@ -476,7 +476,7 @@ class TestSectionDeleteCommand:
         api.get_sections.return_value = iter([[sec]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "section-delete", "Old"], input="n\n")
+        result = runner.invoke(cli, ["--json", "section", "delete", "Old"], input="n\n")
 
         assert result.exit_code == 0
         api.delete_section.assert_not_called()
@@ -488,7 +488,7 @@ class TestSectionDeleteCommand:
         api.get_sections.return_value = iter([[]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "section-delete", "Nonexistent", "-y"])
+        result = runner.invoke(cli, ["--json", "section", "delete", "Nonexistent", "-y"])
 
         assert result.exit_code == 1
 
@@ -507,7 +507,7 @@ class TestLabelEditCommand:
         api.update_label.return_value = updated
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "label-edit", "urgent", "--name", "critical"])
+        result = runner.invoke(cli, ["--json", "label", "edit", "urgent", "--name", "critical"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -525,7 +525,7 @@ class TestLabelEditCommand:
         api.update_label.return_value = updated
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "label-edit", "urgent", "--color", "red"])
+        result = runner.invoke(cli, ["--json", "label", "edit", "urgent", "--color", "red"])
 
         assert result.exit_code == 0
         api.update_label.assert_called_once_with("lbl1", name=None, color="red")
@@ -533,7 +533,7 @@ class TestLabelEditCommand:
     @patch("td.cli.labels.get_client")
     def test_edit_no_flags_errors(self, mock_gc: MagicMock) -> None:
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "label-edit", "urgent"])
+        result = runner.invoke(cli, ["--json", "label", "edit", "urgent"])
 
         assert result.exit_code == 1
 
@@ -547,7 +547,7 @@ class TestLabelDeleteCommand:
         api.get_labels.return_value = iter([[lbl]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "label-delete", "old", "-y"])
+        result = runner.invoke(cli, ["--json", "label", "delete", "old", "-y"])
 
         assert result.exit_code == 0
         api.delete_label.assert_called_once_with("lbl1")
@@ -560,7 +560,7 @@ class TestLabelDeleteCommand:
         api.get_labels.return_value = iter([[lbl]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "label-delete", "old"], input="y\n")
+        result = runner.invoke(cli, ["--json", "label", "delete", "old"], input="y\n")
 
         assert result.exit_code == 0
         api.delete_label.assert_called_once_with("lbl1")
@@ -573,7 +573,7 @@ class TestLabelDeleteCommand:
         api.get_labels.return_value = iter([[lbl]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "label-delete", "old"], input="n\n")
+        result = runner.invoke(cli, ["--json", "label", "delete", "old"], input="n\n")
 
         assert result.exit_code == 0
         api.delete_label.assert_not_called()
@@ -585,7 +585,7 @@ class TestLabelDeleteCommand:
         api.get_labels.return_value = iter([[]])
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "label-delete", "nonexistent", "-y"])
+        result = runner.invoke(cli, ["--json", "label", "delete", "nonexistent", "-y"])
 
         assert result.exit_code == 1
 
@@ -602,7 +602,7 @@ class TestCommentEditCommand:
         api.update_comment.return_value = updated
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "comment-edit", "c1", "Updated", "text"])
+        result = runner.invoke(cli, ["--json", "comment", "edit", "c1", "Updated", "text"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -618,7 +618,9 @@ class TestCommentEditCommand:
         api.update_comment.return_value = updated
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "comment-edit", "c1", "--content", "New content"])
+        result = runner.invoke(
+            cli, ["--json", "comment", "edit", "c1", "--content", "New content"]
+        )
 
         assert result.exit_code == 0
         api.update_comment.assert_called_once_with("c1", content="New content")
@@ -626,7 +628,7 @@ class TestCommentEditCommand:
     @patch("td.cli.comments.get_client")
     def test_edit_no_content_errors(self, mock_gc: MagicMock) -> None:
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "comment-edit", "c1"])
+        result = runner.invoke(cli, ["--json", "comment", "edit", "c1"])
 
         assert result.exit_code == 1
 
@@ -638,7 +640,7 @@ class TestCommentDeleteCommand:
         mock_gc.return_value = api
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "comment-delete", "c1", "-y"])
+        result = runner.invoke(cli, ["--json", "comment", "delete", "c1", "-y"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -651,7 +653,7 @@ class TestCommentDeleteCommand:
         mock_gc.return_value = api
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "comment-delete", "c1"], input="y\n")
+        result = runner.invoke(cli, ["--json", "comment", "delete", "c1"], input="y\n")
 
         assert result.exit_code == 0
         api.delete_comment.assert_called_once_with("c1")
@@ -662,7 +664,283 @@ class TestCommentDeleteCommand:
         mock_gc.return_value = api
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["--json", "comment-delete", "c1"], input="n\n")
+        result = runner.invoke(cli, ["--json", "comment", "delete", "c1"], input="n\n")
 
         assert result.exit_code == 0
         api.delete_comment.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Deprecation shims (ADR-0009)
+#
+# Each hyphenated alias from v0.12.x is kept as a hidden shim through
+# v0.13.0 and removed in v0.14.0. These tests verify: (1) the old name
+# still dispatches to the underlying action, and (2) a one-line
+# deprecation notice is printed to stderr.
+# ---------------------------------------------------------------------------
+
+
+DEPRECATION_TEXT = "is now td"
+
+
+class TestDeprecationShims:
+    @patch("td.cli.projects.get_client")
+    def test_project_add_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.add_project.return_value = _mock_project(name="Foo", id="p99")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "project-add", "Foo"])
+
+        assert result.exit_code == 0
+        assert DEPRECATION_TEXT in result.stderr
+        assert "td project-add is now td project add" in result.stderr
+        api.add_project.assert_called_once()
+
+    @patch("td.cli.projects.get_client")
+    def test_project_edit_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_projects.return_value = iter([[_mock_project(name="Work", id="p1")]])
+        api.update_project.return_value = _mock_project(name="Work stuff", id="p1")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "project-edit", "Work", "--name", "Work stuff"])
+
+        assert result.exit_code == 0
+        assert "td project-edit is now td project edit" in result.stderr
+        api.update_project.assert_called_once_with("p1", name="Work stuff", color=None)
+
+    @patch("td.cli.projects.get_client")
+    def test_project_delete_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_projects.return_value = iter([[_mock_project(name="Old", id="p1")]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "project-delete", "Old", "-y"])
+
+        assert result.exit_code == 0
+        assert "td project-delete is now td project delete" in result.stderr
+        api.delete_project.assert_called_once_with("p1")
+
+    @patch("td.cli.projects.get_client")
+    def test_project_archive_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_projects.return_value = iter([[_mock_project(name="Work", id="p1")]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "project-archive", "Work"])
+
+        assert result.exit_code == 0
+        assert "td project-archive is now td project archive" in result.stderr
+        api.archive_project.assert_called_once_with("p1")
+
+    @patch("td.cli.projects.get_client")
+    def test_project_unarchive_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_projects.return_value = iter([[_mock_project(name="Work", id="p1")]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "project-unarchive", "Work"])
+
+        assert result.exit_code == 0
+        assert "td project-unarchive is now td project unarchive" in result.stderr
+        api.unarchive_project.assert_called_once_with("p1")
+
+    @patch("td.cli.sections.get_client")
+    def test_section_add_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_projects.return_value = iter([[_mock_project(name="Work", id="p1")]])
+        api.add_section.return_value = _mock_section(name="Backlog")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "section-add", "Backlog", "-p", "Work"])
+
+        assert result.exit_code == 0
+        assert "td section-add is now td section add" in result.stderr
+        api.add_section.assert_called_once_with(name="Backlog", project_id="p1")
+
+    @patch("td.cli.sections.get_client")
+    def test_section_edit_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_sections.return_value = iter([[_mock_section(name="Backlog", id="s1")]])
+        api.update_section.return_value = _mock_section(name="Active", id="s1")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "section-edit", "Backlog", "--name", "Active"])
+
+        assert result.exit_code == 0
+        assert "td section-edit is now td section edit" in result.stderr
+        api.update_section.assert_called_once_with("s1", name="Active")
+
+    @patch("td.cli.sections.get_client")
+    def test_section_delete_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_sections.return_value = iter([[_mock_section(name="Old", id="s1")]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "section-delete", "Old", "-y"])
+
+        assert result.exit_code == 0
+        assert "td section-delete is now td section delete" in result.stderr
+        api.delete_section.assert_called_once_with("s1")
+
+    @patch("td.cli.labels.get_client")
+    def test_label_add_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.add_label.return_value = _mock_label(name="urgent")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "label-add", "urgent"])
+
+        assert result.exit_code == 0
+        assert "td label-add is now td label add" in result.stderr
+        api.add_label.assert_called_once_with(name="urgent")
+
+    @patch("td.cli.labels.get_client")
+    def test_label_edit_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_labels.return_value = iter([[_mock_label(name="urgent", id="lbl1")]])
+        api.update_label.return_value = _mock_label(name="critical", id="lbl1")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "label-edit", "urgent", "--name", "critical"])
+
+        assert result.exit_code == 0
+        assert "td label-edit is now td label edit" in result.stderr
+        api.update_label.assert_called_once_with("lbl1", name="critical", color=None)
+
+    @patch("td.cli.labels.get_client")
+    def test_label_delete_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.get_labels.return_value = iter([[_mock_label(name="old", id="lbl1")]])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "label-delete", "old", "-y"])
+
+        assert result.exit_code == 0
+        assert "td label-delete is now td label delete" in result.stderr
+        api.delete_label.assert_called_once_with("lbl1")
+
+    @patch("td.cli.comments.get_client")
+    def test_comment_edit_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.update_comment.return_value = _mock_comment(id="c1", content="Updated")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "comment-edit", "c1", "Updated"])
+
+        assert result.exit_code == 0
+        assert "td comment-edit is now td comment edit" in result.stderr
+        api.update_comment.assert_called_once_with("c1", content="Updated")
+
+    @patch("td.cli.comments.get_client")
+    def test_comment_delete_shim(self, mock_gc: MagicMock) -> None:
+        api = MagicMock()
+        mock_gc.return_value = api
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "comment-delete", "c1", "-y"])
+
+        assert result.exit_code == 0
+        assert "td comment-delete is now td comment delete" in result.stderr
+        api.delete_comment.assert_called_once_with("c1")
+
+
+# ---------------------------------------------------------------------------
+# Comment group flat shortcut (ADR-0009)
+#
+# ``td comment <task_ref> <text>`` must keep working without an explicit
+# ``add`` verb. Implemented via a custom ``CommentGroup.resolve_command``
+# that delegates to the ``add`` subcommand when the first positional
+# argument isn't a known subcommand name. See comments.py for details.
+# ---------------------------------------------------------------------------
+
+
+def _mock_task(**overrides: object) -> MagicMock:
+    t = MagicMock()
+    t.id = overrides.get("id", "t1")
+    t.content = overrides.get("content", "buy milk")
+    t.is_completed = overrides.get("is_completed", False)
+    return t
+
+
+class TestCommentGroupFallback:
+    @patch("td.cli.tasks.get_client")
+    @patch("td.cli.comments.get_client")
+    def test_flat_shortcut_routes_to_add(
+        self, mock_gc_comments: MagicMock, mock_gc_tasks: MagicMock
+    ) -> None:
+        api = MagicMock()
+        mock_gc_comments.return_value = api
+        mock_gc_tasks.return_value = api
+        api.get_task.return_value = _mock_task(id="t1", content="buy milk")
+        api.add_comment.return_value = _mock_comment(id="c1", content="Got oat milk")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "comment", "t1", "Got", "oat", "milk"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        api.add_comment.assert_called_once_with(content="Got oat milk", task_id="t1")
+
+    @patch("td.cli.tasks.get_client")
+    @patch("td.cli.comments.get_client")
+    def test_explicit_add_subcommand(
+        self, mock_gc_comments: MagicMock, mock_gc_tasks: MagicMock
+    ) -> None:
+        """``td comment add <task_ref> <text>`` behaves identically to the
+        flat shortcut and is the discoverable form for agents."""
+        api = MagicMock()
+        mock_gc_comments.return_value = api
+        mock_gc_tasks.return_value = api
+        api.get_task.return_value = _mock_task(id="t1", content="buy milk")
+        api.add_comment.return_value = _mock_comment(id="c1", content="Got oat milk")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "comment", "add", "t1", "Got", "oat", "milk"])
+
+        assert result.exit_code == 0
+        api.add_comment.assert_called_once_with(content="Got oat milk", task_id="t1")
+
+    @patch("td.cli.comments.get_client")
+    def test_edit_subcommand_not_caught_by_fallthrough(self, mock_gc: MagicMock) -> None:
+        """A known subcommand name as first arg must dispatch to the
+        subcommand, not fall through to ``add``. This is the single
+        disambiguation cost the plan calls out: a task literally named
+        after a verb routes to the verb. Users disambiguate with
+        ``td comment add edit "text"``."""
+        api = MagicMock()
+        mock_gc.return_value = api
+        api.update_comment.return_value = _mock_comment(id="c1", content="New")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "comment", "edit", "c1", "--content", "New"])
+
+        assert result.exit_code == 0
+        api.update_comment.assert_called_once_with("c1", content="New")
+        api.add_comment.assert_not_called()
+
+    def test_group_help_renders(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["comment", "--help"])
+
+        # The group help prints even though our error wrapper catches a
+        # SystemExit on group --help. Assert the help content is present.
+        assert "Manage task comments" in result.output
+        assert "add" in result.output
+        assert "edit" in result.output
+        assert "delete" in result.output
+        assert "list" in result.output

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -28,8 +28,6 @@ class TestSchemaCommand:
         expected = {
             "add",
             "comment",
-            "comment-edit",
-            "comment-delete",
             "comments",
             "completed",
             "doctor",
@@ -46,20 +44,12 @@ class TestSchemaCommand:
             "search",
             "show",
             "undo",
-            "project-add",
-            "project-edit",
-            "project-delete",
-            "project-archive",
-            "project-unarchive",
+            "project",
             "projects",
+            "section",
             "sections",
-            "section-add",
-            "section-edit",
-            "section-delete",
+            "label",
             "labels",
-            "label-add",
-            "label-edit",
-            "label-delete",
             "tomorrow",
             "upcoming",
             "overdue",
@@ -71,6 +61,79 @@ class TestSchemaCommand:
             "skill",
         }
         assert set(data["commands"].keys()) == expected
+
+    def test_group_subcommands_in_schema(self) -> None:
+        """Entity groups expose their verbs via a nested ``commands`` dict.
+
+        ADR-0009 moved CRUD commands into entity groups; ADR-0006 requires
+        the schema to describe the full surface. Agents walking the top
+        level must see the verbs on each group without guessing flat
+        name prefixes.
+        """
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schema"])
+        data = json.loads(result.output)
+
+        project = data["commands"]["project"]
+        assert "commands" in project
+        assert set(project["commands"].keys()) == {
+            "add",
+            "edit",
+            "delete",
+            "archive",
+            "unarchive",
+            "list",
+        }
+
+        section = data["commands"]["section"]
+        assert set(section["commands"].keys()) == {"add", "edit", "delete", "list"}
+
+        label = data["commands"]["label"]
+        assert set(label["commands"].keys()) == {"add", "edit", "delete", "list"}
+
+        comment = data["commands"]["comment"]
+        assert set(comment["commands"].keys()) == {"add", "edit", "delete", "list"}
+
+    def test_group_subcommand_carries_params(self) -> None:
+        """Nested subcommand entries must carry the same shape (arguments, options)
+        as leaf commands so agents can invoke them directly."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schema"])
+        data = json.loads(result.output)
+
+        project_add = data["commands"]["project"]["commands"]["add"]
+        assert "description" in project_add
+        assert "arguments" in project_add
+        assert "options" in project_add
+        arg_names = [a["name"] for a in project_add["arguments"]]
+        assert "name" in arg_names
+        option_names = [o["name"] for o in project_add["options"]]
+        assert "parent_name" in option_names
+
+    def test_deprecated_aliases_hidden_from_schema(self) -> None:
+        """The 13 hyphenated CRUD shims from v0.12.x are hidden in v0.13.0
+        and must not appear in the schema. They are removed entirely in
+        v0.14.0 per ADR-0009."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schema"])
+        data = json.loads(result.output)
+
+        deprecated = {
+            "project-add",
+            "project-edit",
+            "project-delete",
+            "project-archive",
+            "project-unarchive",
+            "section-add",
+            "section-edit",
+            "section-delete",
+            "label-add",
+            "label-edit",
+            "label-delete",
+            "comment-edit",
+            "comment-delete",
+        }
+        assert deprecated.isdisjoint(set(data["commands"].keys()))
 
     def test_command_has_description(self) -> None:
         runner = CliRunner()

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -47,6 +47,56 @@ class TestGenerateSkillContent:
         assert "### td quick" not in content
         assert "### td capture" not in content
 
+    def test_entity_group_verbs_are_emitted(self) -> None:
+        """ADR-0009 reshaped CRUD commands into entity groups. The skill
+        generator must recurse into groups so agents see every verb
+        as a fully-qualified invocation (``td project add``) rather than
+        just a bare group header."""
+        schema = generate_schema(cli)
+        content = generate_skill_content(schema)
+
+        # Every primary-path entity-group verb must appear.
+        assert "### td project add" in content
+        assert "### td project edit" in content
+        assert "### td project delete" in content
+        assert "### td project archive" in content
+        assert "### td project unarchive" in content
+        assert "### td project list" in content
+        assert "### td section add" in content
+        assert "### td section edit" in content
+        assert "### td section delete" in content
+        assert "### td label add" in content
+        assert "### td label edit" in content
+        assert "### td label delete" in content
+        assert "### td comment add" in content
+        assert "### td comment edit" in content
+        assert "### td comment delete" in content
+
+    def test_deprecated_hyphenated_names_absent(self) -> None:
+        """The 13 hyphenated CRUD commands from v0.12.x are hidden in
+        v0.13.0 and must not appear in the generated skill content.
+        Agents that see ``td project-add`` in the skill file would
+        surface the deprecation warning to users unnecessarily."""
+        schema = generate_schema(cli)
+        content = generate_skill_content(schema)
+
+        for old in (
+            "### td project-add",
+            "### td project-edit",
+            "### td project-delete",
+            "### td project-archive",
+            "### td project-unarchive",
+            "### td section-add",
+            "### td section-edit",
+            "### td section-delete",
+            "### td label-add",
+            "### td label-edit",
+            "### td label-delete",
+            "### td comment-edit",
+            "### td comment-delete",
+        ):
+            assert old not in content, f"Deprecated alias still in skill content: {old}"
+
 
 class TestInstallUninstall:
     def test_install_creates_file(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- **Replaces 13 hyphenated CRUD commands with four entity-first Click groups** (`project`, `section`, `label`, `comment`) matching gh/docker/kubectl grammar per ADR-0009
- **Permanent shortcuts preserved:** flat plural aliases (`td projects`, `td sections`, etc.) and the flat `td comment <task_ref> <text>` shortcut via a custom `CommentGroup.resolve_command` override
- **Backwards-compatible:** old hyphenated names (`project-add`, `section-edit`, etc.) are hidden aliases that print a deprecation notice on stderr and delegate to the new subcommand; removed in v0.14.0
- **Schema shape is additive** (ADR-0006): group commands gain a nested `commands` key in `td schema` output; skill generator recurses into groups so agents see every verb
- **496 tests pass, 90.65% coverage, lint clean, docs build clean**

## What changed

| Old (v0.12.x)         | New (v0.13.0+)        |
| --------------------- | --------------------- |
| `td project-add`      | `td project add`      |
| `td project-edit`     | `td project edit`     |
| `td project-delete`   | `td project delete`   |
| `td project-archive`  | `td project archive`  |
| `td project-unarchive`| `td project unarchive`|
| `td section-add`      | `td section add`      |
| `td section-edit`     | `td section edit`     |
| `td section-delete`   | `td section delete`   |
| `td label-add`        | `td label add`        |
| `td label-edit`       | `td label edit`       |
| `td label-delete`     | `td label delete`     |
| `td comment-edit`     | `td comment edit`     |
| `td comment-delete`   | `td comment delete`   |

## Files (18 changed, +1586/-289)

**Core changes:** `projects.py`, `sections.py`, `labels.py`, `comments.py` (entity groups), `__init__.py` (registration), `schema.py` (group recursion), `skill.py` (recursive emit)

**Tests:** `test_org_commands.py` (58 tests: primary-path, 13 deprecation shims, 4 comment fallback), `test_schema.py` (8 tests: group subcommands, deprecated aliases hidden), `test_skill.py` (entity group verbs emitted, deprecated names absent)

**Docs:** ADR-0009, `organization.md` rewrite, `index.md` table, CHANGELOG entries, AGENTS.md

## Test plan

- [x] `make check` passes (496 tests, 90.65% coverage, ruff, mypy strict)
- [x] `mkdocs build --strict` passes
- [x] `td --help` shows `project`/`section`/`label`/`comment` as group entries
- [x] `td project --help` shows verb subcommands
- [x] `td project-add Foo` works AND emits stderr deprecation notice
- [x] `td comment 1 "text"` flat shortcut resolves to add via `CommentGroup.resolve_command`
- [x] `td schema` JSON has nested `commands` keys on group entries
- [ ] CI passes

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)